### PR TITLE
feat: Kong API Gateway, OTEL trace fix, Loki + Promtail

### DIFF
--- a/k8s/charts/krystalinex/templates/configmap-kong.yaml
+++ b/k8s/charts/krystalinex/templates/configmap-kong.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.kong.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "krystalinex.fullname" . }}-kong-config
+  labels:
+    {{- include "krystalinex.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kong
+data:
+  kong.yml: |
+    _format_version: "3.0"
+    _transform: true
+
+    services:
+      - name: kx-exchange-api
+        url: http://{{ include "krystalinex.fullname" . }}-server:5000
+        connect_timeout: 10000
+        write_timeout: 60000
+        read_timeout: 60000
+        retries: 2
+        routes:
+          - name: api-route
+            paths:
+              - /api
+            strip_path: false
+            preserve_host: true
+            protocols:
+              - http
+
+    plugins:
+      # OpenTelemetry — the primary reason for Kong in the platform
+      - name: opentelemetry
+        config:
+          endpoint: http://{{ include "krystalinex.fullname" . }}-otel-collector:4318/v1/traces
+          resource_attributes:
+            service.name: kx-gateway
+          header_type: w3c
+
+      # CORS — propagate W3C trace context headers
+      - name: cors
+        config:
+          origins:
+            - "*"
+          methods:
+            - GET
+            - POST
+            - PUT
+            - PATCH
+            - DELETE
+            - OPTIONS
+          headers:
+            - Content-Type
+            - Authorization
+            - traceparent
+            - tracestate
+            - x-trace-id
+            - x-span-id
+            - x-correlation-id
+          exposed_headers:
+            - traceparent
+            - tracestate
+            - x-trace-id
+            - x-span-id
+          credentials: true
+          max_age: 3600
+
+      # Prometheus metrics
+      - name: prometheus
+        config:
+          per_consumer: false
+          status_code_metrics: true
+          latency_metrics: true
+          bandwidth_metrics: true
+          upstream_health_metrics: true
+{{- end }}

--- a/k8s/charts/krystalinex/templates/configmaps.yaml
+++ b/k8s/charts/krystalinex/templates/configmaps.yaml
@@ -127,6 +127,15 @@ data:
           - targets: ['{{ include "krystalinex.fullname" . }}-redis-exporter:9121']
         scrape_interval: 15s
 
+      # Kong API Gateway (Prometheus plugin metrics)
+      {{- if .Values.kong.enabled }}
+      - job_name: 'kong'
+        static_configs:
+          - targets: ['{{ include "krystalinex.fullname" . }}-kong:8100']
+        metrics_path: /metrics
+        scrape_interval: 15s
+      {{- end }}
+
   alerting-rules.yml: |
     # KrystalineX Prometheus Alerting Rules
     groups:

--- a/k8s/charts/krystalinex/templates/deployment-kong.yaml
+++ b/k8s/charts/krystalinex/templates/deployment-kong.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.kong.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "krystalinex.fullname" . }}-kong
+  labels:
+    {{- include "krystalinex.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kong
+spec:
+  replicas: {{ .Values.kong.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "krystalinex.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: kong
+  template:
+    metadata:
+      labels:
+        {{- include "krystalinex.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: kong
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-kong.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: kong
+          image: "{{ .Values.kong.image.repository }}:{{ .Values.kong.image.tag }}"
+          imagePullPolicy: {{ .Values.kong.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /kong/kong.yml
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: "0.0.0.0:8001"
+            - name: KONG_STATUS_LISTEN
+              value: "0.0.0.0:8100"
+            - name: KONG_PROXY_LISTEN
+              value: "0.0.0.0:8000"
+            - name: KONG_TRACING_INSTRUMENTATIONS
+              value: "all"
+            - name: KONG_TRACING_SAMPLING_RATE
+              value: "1.0"
+          ports:
+            - name: proxy
+              containerPort: 8000
+              protocol: TCP
+            - name: admin
+              containerPort: 8001
+              protocol: TCP
+            - name: status
+              containerPort: 8100
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: status
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: status
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.kong.resources | nindent 12 }}
+          volumeMounts:
+            - name: kong-config
+              mountPath: /kong
+              readOnly: true
+      volumes:
+        - name: kong-config
+          configMap:
+            name: {{ include "krystalinex.fullname" . }}-kong-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "krystalinex.fullname" . }}-kong
+  labels:
+    {{- include "krystalinex.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kong
+spec:
+  type: ClusterIP
+  ports:
+    - name: proxy
+      port: {{ .Values.kong.service.ports.proxy | default 8000 }}
+      targetPort: proxy
+      protocol: TCP
+    - name: admin
+      port: {{ .Values.kong.service.ports.admin | default 8001 }}
+      targetPort: admin
+      protocol: TCP
+    - name: status
+      port: 8100
+      targetPort: status
+      protocol: TCP
+  selector:
+    {{- include "krystalinex.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: kong
+{{- end }}

--- a/k8s/charts/krystalinex/templates/ingress.yaml
+++ b/k8s/charts/krystalinex/templates/ingress.yaml
@@ -38,9 +38,15 @@ spec:
                 port:
                   number: 80
                 {{- else if eq .service "server" }}
+                {{- if $.Values.kong.enabled }}
+                name: {{ include "krystalinex.fullname" $ }}-kong
+                port:
+                  number: 8000
+                {{- else }}
                 name: {{ include "krystalinex.fullname" $ }}-server
                 port:
                   number: 5000
+                {{- end }}
                 {{- else if eq .service "grafana" }}
                 name: {{ include "krystalinex.fullname" $ }}-grafana
                 port:

--- a/k8s/charts/krystalinex/values.yaml
+++ b/k8s/charts/krystalinex/values.yaml
@@ -131,18 +131,7 @@ postgresql:
         memory: 256Mi
 
 kongPostgresql:
-  enabled: true
-  auth:
-    username: kong
-    database: kong
-    existingSecret: krystalinex-kong-secrets
-    secretKeys:
-      adminPasswordKey: postgres-password
-      userPasswordKey: password
-  primary:
-    persistence:
-      enabled: true
-      size: 5Gi
+  enabled: false  # DB-less mode — declarative config via ConfigMap
 
 rabbitmq:
   enabled: true
@@ -306,27 +295,23 @@ promtail:
 
 kong:
   enabled: true
+  replicaCount: 1
   image:
-    repository: kong/kong-gateway
-    tag: latest
+    repository: kong
+    tag: "3.9"
+    pullPolicy: IfNotPresent
   service:
-    type: LoadBalancer  # For external access
+    type: ClusterIP
     ports:
       proxy: 8000
-      proxySSL: 8443
       admin: 8001
-      manager: 8002
-  env:
-    database: postgres
-    pg_host: "{{ .Release.Name }}-kongdatabase-postgresql"
-    pg_user: kong
   resources:
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
 
 # =============================================================================
 # OPTIONAL / DEV-ONLY SERVICES

--- a/k8s/charts/krystalinex/values.yaml
+++ b/k8s/charts/krystalinex/values.yaml
@@ -277,7 +277,7 @@ loki:
       memory: 256Mi
 
 promtail:
-  enabled: false
+  enabled: true
   image:
     repository: grafana/promtail
     tag: "3.0.0"

--- a/k8s/charts/krystalinex/values.yaml
+++ b/k8s/charts/krystalinex/values.yaml
@@ -258,7 +258,7 @@ prometheus:
       memory: 256Mi
 
 loki:
-  enabled: false
+  enabled: true
   image:
     repository: grafana/loki
     tag: "3.0.0"

--- a/k8s/charts/krystalinex/values.yaml
+++ b/k8s/charts/krystalinex/values.yaml
@@ -19,7 +19,7 @@ server:
   replicaCount: 1
   image:
     repository: moebiusx/krystalinex-server
-    tag: v2.6.0
+    tag: v2.6.2
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/k8s/charts/krystalinex/values.yaml
+++ b/k8s/charts/krystalinex/values.yaml
@@ -19,7 +19,7 @@ server:
   replicaCount: 1
   image:
     repository: moebiusx/krystalinex-server
-    tag: v2.6.2
+    tag: v2.6.4
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -18,9 +18,12 @@ COPY server ./server
 COPY shared ./shared
 COPY tsconfig.json ./
 
-# Bundle server into a single ESM file (external node_modules)
-# Exclude server/vite.ts — it's dev-only (dynamic import guarded by NODE_ENV check)
-RUN npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:./vite
+# Bundle OTEL setup as separate entry (must load BEFORE main bundle for ESM hook registration)
+# Then bundle the main server with ./otel marked external (resolved at runtime)
+# Fix ESM extension: Node.js ESM requires explicit .js extension on imports
+RUN npx esbuild server/otel.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/otel.js && \
+    npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:./vite --external:./otel && \
+    sed -i 's|import "./otel"|import "./otel.js"|' dist/index.js
 
 # Now install production-only deps for the final image
 RUN rm -rf node_modules && \
@@ -66,4 +69,6 @@ EXPOSE 5000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:5000/health || exit 1
 
-CMD ["node", "dist/index.js"]
+# --import loads OTEL before any other module, so auto-instrumentation hooks
+# (pg, http, amqplib) register before those modules are imported by the main bundle
+CMD ["node", "--import", "./dist/otel.js", "dist/index.js"]

--- a/server/core/order-service.ts
+++ b/server/core/order-service.ts
@@ -220,6 +220,8 @@ export class OrderService {
         }
 
         // Execute via RabbitMQ - MUST preserve the current context for proper trace propagation
+        // Capture POST span context BEFORE crossing the async boundary (RabbitMQ publish/consume)
+        // See: docs/observability/01_OTEL_TRACING_GUIDE.md §8 "Express Async Handler Context Loss"
         const currentContext = context.active();
         const activeSpanForRabbit = trace.getSpan(currentContext);
 
@@ -229,8 +231,7 @@ export class OrderService {
         }, 'Calling RabbitMQ with captured context');
 
         try {
-            // Execute within the captured context to ensure trace propagation
-            const publishPromise = rabbitMQClient.publishOrderAndWait({
+            const executionResponse = await rabbitMQClient.publishOrderAndWait({
                 orderId,
                 correlationId,
                 pair: request.pair,
@@ -243,8 +244,6 @@ export class OrderService {
                 userId,
                 timestamp: new Date().toISOString()
             }, 5000);
-
-            const executionResponse = await context.with(currentContext, () => publishPromise);
 
             const safeExecutionResponse = executionResponse ?? {
                 status: 'REJECTED',
@@ -265,55 +264,60 @@ export class OrderService {
                 processorId: safeExecutionResponse.processorId
             }, 'Order execution response received');
 
-            if (safeExecutionResponse.status === 'FILLED') {
-                try {
-                    await this.updateUserWallet(userId, request.side, request.quantity, safeExecutionResponse.fillPrice);
-                    // Emit business metrics for successful trade
-                    recordTrade(request.pair, request.side, request.quantity, safeExecutionResponse.totalValue);
-                    recordOrderMetrics(request.side, 'FILLED', 0); // Duration tracked separately
-                    // Check for whale transaction
-                    amountAnomalyDetector.checkOrder({
-                        orderId,
-                        userId,
-                        side: request.side,
-                        pair: request.pair,
-                        amount: request.quantity,
-                        traceId,
-                    });
-                    // Proof of Integrity™ — Generate ZK proof (non-blocking, fire-and-forget)
-                    zkProofService.generateTradeProof({
-                        orderId,
-                        traceId,
-                        fillPrice: safeExecutionResponse.fillPrice,
-                        quantity: request.quantity,
-                        userId,
-                        binancePrice: price,
-                    }).catch(err => logger.error({ err, orderId }, 'ZK proof generation failed'));
-                } catch (walletError: unknown) {
-                    // Wallet update failed (e.g., balance constraint violation)
-                    // Mark order as rejected to prevent stuck pending orders
-                    logger.error({
-                        err: walletError,
-                        orderId,
-                        userId,
-                        side: request.side,
-                        quantity: request.quantity
-                    }, 'Wallet update failed - marking order as rejected');
+            // Restore POST span context for post-processing (wallet update, ZK proof)
+            // After RabbitMQ round-trip, the active context may have shifted to the AMQP consumer context.
+            // context.with() ensures all child spans (PG queries, ZK proof) join the POST trace.
+            await context.with(currentContext, async () => {
+                if (safeExecutionResponse.status === 'FILLED') {
+                    try {
+                        await this.updateUserWallet(userId, request.side, request.quantity, safeExecutionResponse.fillPrice);
+                        // Emit business metrics for successful trade
+                        recordTrade(request.pair, request.side, request.quantity, safeExecutionResponse.totalValue);
+                        recordOrderMetrics(request.side, 'FILLED', 0); // Duration tracked separately
+                        // Check for whale transaction
+                        amountAnomalyDetector.checkOrder({
+                            orderId,
+                            userId,
+                            side: request.side,
+                            pair: request.pair,
+                            amount: request.quantity,
+                            traceId,
+                        });
+                        // Proof of Integrity™ — Generate ZK proof (non-blocking, fire-and-forget)
+                        zkProofService.generateTradeProof({
+                            orderId,
+                            traceId,
+                            fillPrice: safeExecutionResponse.fillPrice,
+                            quantity: request.quantity,
+                            userId,
+                            binancePrice: price,
+                        }).catch(err => logger.error({ err, orderId }, 'ZK proof generation failed'));
+                    } catch (walletError: unknown) {
+                        // Wallet update failed (e.g., balance constraint violation)
+                        // Mark order as rejected to prevent stuck pending orders
+                        logger.error({
+                            err: walletError,
+                            orderId,
+                            userId,
+                            side: request.side,
+                            quantity: request.quantity
+                        }, 'Wallet update failed - marking order as rejected');
 
-                    await this.updateOrderRecord(orderId, {
-                        status: 'REJECTED',
-                        fillPrice: safeExecutionResponse.fillPrice,
-                        totalValue: safeExecutionResponse.totalValue
-                    });
+                        await this.updateOrderRecord(orderId, {
+                            status: 'REJECTED',
+                            fillPrice: safeExecutionResponse.fillPrice,
+                            totalValue: safeExecutionResponse.totalValue
+                        });
 
-                    throw new OrderError('Settlement failed - order rejected');
+                        throw new OrderError('Settlement failed - order rejected');
+                    }
                 }
-            }
 
-            await this.updateOrderRecord(orderId, {
-                status: safeExecutionResponse.status as "PENDING" | "FILLED" | "REJECTED",
-                fillPrice: safeExecutionResponse.fillPrice,
-                totalValue: safeExecutionResponse.totalValue
+                await this.updateOrderRecord(orderId, {
+                    status: safeExecutionResponse.status as "PENDING" | "FILLED" | "REJECTED",
+                    fillPrice: safeExecutionResponse.fillPrice,
+                    totalValue: safeExecutionResponse.totalValue
+                });
             });
 
             return {

--- a/server/otel.ts
+++ b/server/otel.ts
@@ -1,3 +1,9 @@
+// Register ESM loader hooks so import-in-the-middle can intercept
+// built-in modules (http, etc.) for proper context propagation.
+// Must run before the main module's imports are resolved.
+import { register } from 'node:module';
+register('import-in-the-middle/hook.mjs', import.meta.url);
+
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';

--- a/server/services/rabbitmq-client.ts
+++ b/server/services/rabbitmq-client.ts
@@ -269,6 +269,12 @@ export class RabbitMQClient {
             status: response.status,
           }, 'Received execution response');
 
+          // Extract trace context from response headers (matcher sends original POST traceparent)
+          // This ensures the Promise continuation inherits the POST span context
+          // See: docs/observability/01_OTEL_TRACING_GUIDE.md §5 "RabbitMQ Consumer: Context Extraction"
+          const headers = msg.properties.headers || {};
+          const responseContext = propagation.extract(context.active(), headers);
+
           // Convert legacy response format
           const executionResponse: ExecutionResponse = {
             orderId: response.orderId || `ORD-${response.paymentId}`,
@@ -283,7 +289,11 @@ export class RabbitMQClient {
 
           const callback = this.pendingResponses.get(correlationId);
           if (callback) {
-            callback(executionResponse);
+            // Invoke within extracted context so Promise continuation (submitOrder)
+            // runs with POST span as parent — wallet update + ZK proof spans join the trace
+            context.with(responseContext, () => {
+              callback(executionResponse);
+            });
             logger.debug({ correlationId }, 'Execution delivered to waiting caller');
           } else {
             logger.warn({ correlationId }, 'No pending callback found for execution response');


### PR DESCRIPTION
## Summary

### Kong API Gateway (K8s)
- Kong 3.9 OSS deployed in DB-less mode with declarative ConfigMap
- OTEL plugin traces as \kx-gateway\ service (W3C format) → OTEL collector
- CORS plugin propagates \	raceparent\/\	racestate\ headers
- Prometheus plugin exposes gateway metrics on \:8100/metrics\
- Ingress routes \/api\ through Kong when enabled, falls back to direct
- Jaeger now shows **4 services**: kx-wallet → kx-gateway → kx-exchange → kx-matcher

### OTEL ESM Context Propagation Fix
- Fixed auto-instrumentation regression from esbuild ESM migration
- Separate otel.ts entry point loaded via \--import\ flag (pre-loads before main bundle)
- Registered \import-in-the-middle\ ESM loader hooks for proper HTTP context wrapping
- RabbitMQ response consumer extracts trace context from headers
- Post-response processing wrapped in captured POST span context
- Trade traces restored from 12 → 32+ spans with correct parent-child hierarchy

### Loki + Promtail
- Loki 3.0 enabled on worker1 (resolves Grafana DNS errors)
- Promtail DaemonSet shipping pod logs from kube and worker1
- JSON pipeline parses Pino logs with traceId/spanId structured metadata
- 31 component labels indexed

### Verified in Production (Helm rev 150)
- Kong pod running, all API traffic routing through gateway
- Trade submitted and filled through full chain
- Loki receiving logs, Grafana log queries functional
- All 1050+ tests passing