### PR TITLE
fix(wallet): make the legacy transfer atomic

### DIFF
--- a/server/core/order-service.ts
+++ b/server/core/order-service.ts
@@ -406,9 +406,13 @@ export class OrderService {
                     spanId
                 });
 
-                // Update wallets
-                await walletService.updateBalance(request.fromUserId, 'BTC', fromWallet.btc - request.amount);
-                await walletService.updateBalance(request.toUserId, 'BTC', toWallet.btc + request.amount);
+                // Move the funds through the atomic transfer primitive: a single
+                // locked transaction re-reads both wallets (SELECT ... FOR UPDATE),
+                // debits the sender and credits the receiver together. The previous
+                // two-step updateBalance() wrote absolute balances derived from a
+                // stale read, so concurrent transfers could lose an update or a
+                // mid-operation failure could leave the debit and credit out of sync.
+                await walletService.transfer(request.fromUserId, request.toUserId, 'BTC', request.amount);
 
                 // Update transfer status
                 await storage.updateTransfer(transferId, 'COMPLETED');


### PR DESCRIPTION
`orderService.processTransfer()` (reached from the legacy `/transfers` endpoint)
moved funds with two independent `walletService.updateBalance()` calls that set
absolute balances computed from a read taken *before* the writes:

```
await walletService.updateBalance(from, 'BTC', fromWallet.btc - amount);
await walletService.updateBalance(to,   'BTC', toWallet.btc   + amount);
```

Two issues: concurrent transfers can lose updates (both read the same starting
balance), and a crash between the two writes leaves a debit with no matching
credit.

**Change:** delegate the money movement to `walletService.transfer()`, which
performs both legs inside a single transaction with `SELECT ... FOR UPDATE` on
both wallets. This is the same primitive the P2P `/api/v1/wallet/transfer` route
already uses, so the two paths now behave identically. The surrounding transfer
record and tracing are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)