### PR TITLE
fix(monitor): require an operator key for the destructive baseline reset

### DIFF
--- a/server/monitor/routes.ts
+++ b/server/monitor/routes.ts
@@ -206,6 +206,14 @@ router.post('/recalculate', async (req, res) => {
  * Clear all baselines for fresh validation
  */
 router.delete('/reset', async (req, res) => {
+    // Destructive maintenance operation (TRUNCATE). Fail closed: it is only
+    // available when an operator key is configured, and the caller must present
+    // that key. With no key set, the route always refuses.
+    const maintenanceKey = process.env.MONITOR_MAINTENANCE_KEY;
+    if (!maintenanceKey || req.get('x-maintenance-key') !== maintenanceKey) {
+        return res.status(403).json({ error: 'Not authorized' });
+    }
+
     const { drizzleDb } = await import('../db/drizzle');
     const { sql } = await import('drizzle-orm');
 


### PR DESCRIPTION
`DELETE /api/monitor/reset` runs a `TRUNCATE` across the baseline tables but had
no access control on the monitor router (which is otherwise public/read-only),
so any caller could wipe the monitoring baselines.

**Change:** gate the route behind a configured `MONITOR_MAINTENANCE_KEY`
presented via an `x-maintenance-key` header. It fails closed — when no key is
configured the route always returns `403`, so the destructive path is off by
default. Read-only monitor endpoints are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)