### PR TITLE
fix(telemetry): redact the destination address in the transfer span

### DIFF
--- a/client/src/components/transfer-form.tsx
+++ b/client/src/components/transfer-form.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { trace, context, SpanStatusCode } from "@opentelemetry/api";
 import { createLogger } from "@/lib/logger";
+import { redactAddressForTelemetry } from "@/lib/trace-utils";
 
 const log = createLogger('TransferForm');
 import { Button } from "@/components/ui/button";
@@ -109,7 +110,9 @@ export function TransferForm() {
                 const parentContext = context.active();
 
                 try {
-                    parentSpan.setAttribute('transfer.toAddress', data.toAddress);
+                    // Redact the destination address before it reaches the trace
+                    // backend — a full wallet address is directly-identifying PII.
+                    parentSpan.setAttribute('transfer.toAddress', redactAddressForTelemetry(data.toAddress));
                     parentSpan.setAttribute('transfer.amount', data.amount);
                     parentSpan.setAttribute('transfer.asset', data.asset);
 

--- a/client/src/lib/trace-utils.ts
+++ b/client/src/lib/trace-utils.ts
@@ -32,3 +32,17 @@ export function isValidJaegerTraceId(traceId: string): boolean {
     const formatted = formatTraceIdForJaeger(traceId);
     return /^[0-9a-f]{32}$/i.test(formatted);
 }
+
+/**
+ * Redact a directly-identifying value (e.g. a wallet address) before it is
+ * written to a span attribute. Span attributes are exported to the trace
+ * backend, so a full identifier there is effectively published. Keep a short
+ * head/tail for debuggability; fully mask anything too short to redact
+ * meaningfully.
+ */
+export function redactAddressForTelemetry(address: string | null | undefined): string {
+    if (!address) return '';
+    const a = String(address);
+    if (a.length <= 12) return '[redacted]';
+    return `${a.slice(0, 6)}...${a.slice(-4)}`;
+}


### PR DESCRIPTION
The transfer form wrote the full recipient wallet address into the
`transfer.toAddress` span attribute. Span attributes are exported to the trace
backend, so a directly-identifying destination address was effectively
published there.

**Change:** add a small `redactAddressForTelemetry` helper (keeps `first6...last4`,
masks anything too short) in `client/src/lib/trace-utils.ts` and apply it at the
one span-write site. The value sent in the request body and shown in the UI is
unchanged — only the telemetry attribute is redacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)