### PR TITLE
fix(ui): describe the solvency panel as a published commitment

### DIFF
--- a/client/src/components/transparency-dashboard.tsx
+++ b/client/src/components/transparency-dashboard.tsx
@@ -712,7 +712,7 @@ export function TransparencyDashboard() {
               {zkStats?.solvency.lastGeneratedAt && (
                 <div className="mt-4 flex items-center justify-center gap-2 text-xs text-cyan-100/40">
                   <Shield className="h-3.5 w-3.5 text-purple-400" />
-                  <span>Solvency proof: verified {zkStats.solvencyProofAge}s ago</span>
+                  <span>Reserve commitment published {zkStats.solvencyProofAge}s ago</span>
                   <span className="text-purple-400/60">•</span>
                   <span className="font-mono text-purple-400/60">{zkStats.solvency.totalReserveCommitment?.slice(0, 12)}...</span>
                 </div>


### PR DESCRIPTION
The transparency panel labelled the solvency status "Solvency proof: verified",
which reads as a proven reserves-≥-liabilities guarantee — stronger than what
the published reserve commitment on display actually demonstrates.

**Change:** reword to "Reserve commitment published …", which matches what the
panel shows (the reserve commitment and its age). Copy-only; no functional or
data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)