### PR TITLE
docs: publish security hardening + operational transparency guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ naming policy.
 | [Getting Started](docs/GETTING_STARTED.md) | Local setup, repo map, and useful commands. |
 | [Architecture](docs/architecture/01_ARCHITECTURE.md) | System design, data flow, and service interactions. |
 | [Public Documentation Catalog](docs/PUBLIC_DOCUMENTS.md) | Public-safe document map and disclosure boundaries. |
+| [Secure Operational Transparency](docs/SECURE_OPERATIONAL_TRANSPARENCY.md) | Defensive principles for exposing public data while protecting accounts, money, and secrets. |
+| [Security Hardening Changelog](docs/SECURITY_HARDENING_CHANGELOG.md) | Our hardening philosophy and a public-safe summary of what we harden. |
 
 ## Status Legend
 

--- a/docs/DEPLOYMENT_PROVENANCE_AND_DRIFT.md
+++ b/docs/DEPLOYMENT_PROVENANCE_AND_DRIFT.md
@@ -1,0 +1,66 @@
+# Deployment Provenance and Drift
+
+Status: Public
+Audience: DevOps, regulators, enterprise buyers
+Classification: Public-safe overview
+
+For financial infrastructure, "it's deployed" is not enough. You should be able
+to answer, at any moment: *exactly which artifact is running, where it came from,
+and whether it still matches what we intended to deploy.* This note describes the
+provenance-and-drift discipline the lab treats as table stakes. It is a set of
+practices, not a description of any private pipeline.
+
+## 1. Pin artifacts by digest, not by tag
+
+A floating tag (`:latest`, `:stable`) resolves to "whatever that name pointed at
+when the node happened to pull." That is neither reproducible nor auditable — two
+nodes can run different code under the same tag. Pin every production image by
+content digest (`@sha256:…`) and resolve the digest at release time.
+
+Benefit: the running artifact is exactly identifiable and cannot silently change
+underneath you.
+
+## 2. Provenance: know where the artifact came from
+
+Every production artifact should be traceable to the commit and build that
+produced it. Record the source revision, the build inputs, and (ideally) a signed
+attestation, so a reviewer can walk from "this container is running" back to "this
+reviewed change built it."
+
+## 3. Patch the base, don't just build on it
+
+A pinned base image is still only as safe as its last rebuild. Production image
+builds should apply OS-level security updates as an explicit step, so a known-CVE
+package in the base layer is patched rather than inherited indefinitely.
+
+## 4. Lock dependencies with hashes
+
+Application dependencies should be resolved through a lockfile with content
+hashes, and version ranges kept to compatible bounds. Loose ranges mean a build
+can quietly pull a newer, unreviewed version; hash-pinned locks make the
+dependency set reproducible and tamper-evident.
+
+## 5. Detect drift continuously
+
+Deployed state drifts — someone hotfixes a running config, an operator edits a
+resource by hand, a dependency gets bumped out of band. Drift detection compares
+*what is actually running* against *what the source of truth declares* and flags
+the delta. For regulated infrastructure this is the difference between "we think
+prod matches main" and "we can prove it."
+
+Operational note: the automation that performs drift checks needs credentials.
+Source those from your secrets manager / CI secret store, never from a file left
+on the runner.
+
+## 6. Deploy behind a guard
+
+A guided deploy should verify preconditions (image pinned, provenance present,
+config validated, drift clean) before it touches production, and make rollback a
+first-class, rehearsed step rather than an improvisation.
+
+---
+
+Why a public lab cares: provenance and drift are exactly what an external auditor,
+regulator, or enterprise buyer asks about when they evaluate whether financial
+infrastructure is operated responsibly. Publishing the *discipline* (not the
+private pipeline) is part of the transparency promise.

--- a/docs/PUBLIC_DOCUMENTS.md
+++ b/docs/PUBLIC_DOCUMENTS.md
@@ -9,6 +9,25 @@ model, and operational philosophy. Keep source code internals, exact control
 logic, credentials, private deployment values, provider-specific integrations,
 and security-sensitive runbooks private.
 
+## Published in This Repository
+
+The following items from the publishing set are now live in the lab:
+
+- [Secure Operational Transparency Principles](SECURE_OPERATIONAL_TRANSPARENCY.md)
+  — generic defensive principles for token integrity, authentication throttling,
+  secrets at rest, and keeping the public surface read-only and fail-closed.
+- [Deployment Provenance and Drift](DEPLOYMENT_PROVENANCE_AND_DRIFT.md) — why
+  digest pinning, provenance, dependency locking, and drift detection matter for
+  financial infrastructure.
+- [Security Hardening — Philosophy and Public Changelog](SECURITY_HARDENING_CHANGELOG.md)
+  — how we review and harden, and the public-safe categories of what changed.
+- [Hardening Samples](samples/README.md) — reference implementations that
+  accompany the docs (not wired into the build).
+
+Each was written to the redaction checklist below: generic patterns and
+defensive principles only, with no internal thresholds, topology, circuit
+parameters, secret names, or private hostnames.
+
 ## Recommended Publishing Set
 
 | Priority | Document | Audience | Public-safe angle | Keep private |

--- a/docs/SECURE_OPERATIONAL_TRANSPARENCY.md
+++ b/docs/SECURE_OPERATIONAL_TRANSPARENCY.md
@@ -1,0 +1,101 @@
+# Secure Operational Transparency Principles
+
+Status: Public
+Audience: security, compliance, and platform teams
+Classification: Public-safe overview
+
+Krystaline's thesis is that financial infrastructure should be inspectable. But
+"inspectable" is not "unguarded" — exposing useful public operational data and
+protecting the account, money, and secret surfaces are the *same* discipline
+seen from two sides. This note collects the defensive principles the lab holds
+itself to. Everything here is a generic, industry-standard pattern; none of it
+describes a specific internal control value.
+
+## 1. Token integrity — pin what a verifier will accept
+
+A JWT (or any signed token) verifier must **pin the algorithm set it accepts**.
+If it accepts "whatever the token header claims", an attacker can present a token
+with `alg: none` (unsigned) or swap a symmetric/asymmetric algorithm to bypass
+the signature check entirely (`alg` confusion).
+
+Principle: centralize verify/sign options so the accepted algorithm is set in one
+place and cannot drift between call sites. A call site that legitimately needs a
+different algorithm gets its own explicit options object rather than widening the
+shared one.
+
+## 2. Throttling authentication — two layers, not one
+
+Per-IP rate limiting alone does not stop distributed credential stuffing that
+stays under any single IP's limit. Pair it with a **per-account** control: track
+consecutive failed logins and temporarily lock the account after a threshold,
+clearing on any successful auth.
+
+Principle: the two layers cover different attackers (one noisy source vs. many
+quiet ones). Keep the lock window short so the mechanism can't be weaponized into
+a denial-of-service against a targeted user, and make thresholds deployment-tuned
+rather than published.
+
+## 3. Codes and tokens — use a CSPRNG
+
+Anything a user must not guess — email verification codes, password-reset codes,
+recovery codes — must come from a cryptographically secure RNG, never
+`Math.random()`. `Math.random()` is a predictable PRNG; observing a few outputs
+can let an attacker predict others and forge another user's code.
+
+Principle: `crypto.randomInt` / `crypto.randomBytes` for anything security-bearing.
+
+## 4. Secrets at rest — encrypt seeds, hash codes
+
+Authenticator (TOTP) seeds should be encrypted at rest with authenticated
+encryption (AES-256-GCM), so a database read alone yields no usable 2FA material.
+Recovery/backup codes should be stored only as one-way hashes and shown to the
+user exactly once.
+
+Principle: seeds are secrets you must recover (encrypt); codes are secrets you
+only need to *check* (hash). In production the encryption key is required — fail
+closed if it is missing rather than falling back to a derived dev key.
+
+## 5. Transport headers — minimize the attack surface
+
+- **Content-Security-Policy:** production policy should not carry
+  `script-src 'unsafe-inline'`. Inline-script allowances are a dev-server
+  convenience; shipping them to production widens XSS impact.
+- **CORS credentials:** send `Access-Control-Allow-Credentials: true` only for
+  explicitly allow-listed origins, never unconditionally. Reflecting credentials
+  back to arbitrary origins defeats the point of the allow-list.
+
+## 6. The public surface fails closed
+
+Public transparency endpoints are read-only by design. The safety properties
+that keep them that way:
+
+- **Read-only, enforced:** public/anonymous access must not be able to reach any
+  mutating or destructive operation, even by route aliasing.
+- **Fail closed:** if public exposure is misconfigured, the safe default is to
+  deny, not to expose. Production should refuse to start (or refuse the request)
+  rather than serve a privileged route anonymously.
+- **Rate-limited everywhere:** every public alias — versioned and unversioned —
+  carries the same limiter. An unrated alias of a rated route is a hole.
+- **Bounded pass-through:** if a public endpoint proxies a query language
+  (e.g. metrics queries), bound it — cap query size, time range, resolution, and
+  add a timeout — so it can't be turned into a resource-exhaustion lever.
+- **Exact lookups, not dumps:** a public or semi-public lookup returns the one
+  record the caller asked for, never a bulk export of everyone's data.
+- **Destructive operations are gated:** maintenance actions that delete or reset
+  data require an explicit, non-default opt-in and authentication — never an open
+  route.
+
+## 7. Internal services are not "trusted" by default
+
+A service being inside the cluster is not authentication. Internal ML/inference
+or worker services should still require a credential from their callers and bound
+their inputs (size, shape, rate). Local developer transports (e.g. a local MCP or
+debug HTTP server) should bind to loopback and drop wildcard CORS, so they aren't
+reachable from off-box.
+
+---
+
+These principles map directly onto the lab's public promise: *public health,
+volume, and proof status by default; account data, money movement, and operator
+actions behind explicit authorization.* Transparency and safety are the same
+engineering habit.

--- a/docs/SECURITY_HARDENING_CHANGELOG.md
+++ b/docs/SECURITY_HARDENING_CHANGELOG.md
@@ -1,0 +1,64 @@
+# Security Hardening — Philosophy and Public Changelog
+
+Status: Public
+Audience: contributors, security reviewers, technical buyers
+Classification: Public-safe overview
+
+## Philosophy
+
+We periodically run a structured security review across the platform's main
+domains — authentication and session, money movement, HTTP API and
+access-control, secrets and infrastructure, and the proof/telemetry surfaces —
+and then harden against what we find. Two commitments shape how we talk about it:
+
+- **We publish the pattern, not the postmortem.** The lab shares the generic
+  hardening lessons (pin your token algorithm, encrypt seeds at rest, bound your
+  public query surface). It does not publish the specific internal weakness, the
+  exact thresholds, or anything that reads as an attack recipe against the live
+  system.
+- **Hardening is continuous, not a milestone.** A "we passed a security review"
+  banner is not a product claim. The value is the discipline of reviewing,
+  remediating, and re-verifying — repeatedly.
+
+## What "hardened" means here, by category
+
+The categories below are the durable ones; the list is a public-safe summary of
+the *kinds* of improvements we make, not a live findings index.
+
+**Authentication & session**
+- Token verification pins its accepted algorithm set.
+- Password/verification/recovery codes come from a CSPRNG.
+- Per-account lockout complements per-IP rate limiting.
+- Authenticator seeds are encrypted at rest; recovery codes are hashed.
+- One bcrypt work factor, defined once.
+- Sensitive verification endpoints are individually rate-limited.
+
+**HTTP API & public surface**
+- Every public route — including unversioned aliases — is rate-limited.
+- Destructive maintenance operations require explicit, authenticated opt-in.
+- Public pass-through queries are bounded (size, range, resolution, timeout).
+- Lookups return exact matches, never bulk exports.
+- Anonymous access is read-only and fails closed.
+
+**Money movement**
+- Value-moving operations are atomic and support idempotency keys.
+- Demonstration/simulation endpoints are environment-gated and capped.
+
+**Secrets & infrastructure**
+- Observability tooling ships with no anonymous admin and no default password.
+- Internal services authenticate their callers and bound their inputs.
+- Local developer transports bind to loopback.
+- Workloads run non-root with least privilege; images are digest-pinned.
+- Base images are patched at build; dependencies are hash-locked.
+
+**Proofs & telemetry**
+- Public claims are only as strong as what is actually verifiable — copy is kept
+  honest, and proofs are independently checkable by third parties.
+- Client telemetry redacts directly-identifying values before they leave the
+  authenticated boundary.
+- In-memory caches are bounded (size + TTL).
+
+---
+
+See also: [Secure Operational Transparency Principles](SECURE_OPERATIONAL_TRANSPARENCY.md)
+and [Deployment Provenance and Drift](DEPLOYMENT_PROVENANCE_AND_DRIFT.md).

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -1,0 +1,22 @@
+# Hardening Samples
+
+Reference implementations that accompany the security-hardening docs. These are
+illustrative, copy-and-adapt snippets — they live under `docs/` and are
+deliberately **excluded from the application build** (they are not part of the
+TypeScript `include`), so they are documentation, not wired-in code.
+
+Where a pattern is already implemented in the running application, that is noted
+below so you don't wire it twice.
+
+| Sample | Pattern | See |
+|---|---|---|
+| [`jwt-options.ts`](jwt-options.ts) | Pin the accepted JWT algorithm set in one place | [Secure Operational Transparency §1](../SECURE_OPERATIONAL_TRANSPARENCY.md) |
+| [`auth-constants.ts`](auth-constants.ts) | Single source of truth for the bcrypt work factor | [§ hardening changelog](../SECURITY_HARDENING_CHANGELOG.md) |
+| [`crypto-box.ts`](crypto-box.ts) | AES-256-GCM seal/open for secrets at rest | [Secure Operational Transparency §4](../SECURE_OPERATIONAL_TRANSPARENCY.md) |
+| [`redact-telemetry.ts`](redact-telemetry.ts) | Redact identifiers before they reach a telemetry sink | already live in `client/src/lib/trace-utils.ts` (`redactAddressForTelemetry`) |
+| [`idempotency-key-pattern.md`](idempotency-key-pattern.md) | Exactly-once for money-moving endpoints | [Secure Operational Transparency §6](../SECURE_OPERATIONAL_TRANSPARENCY.md) |
+| [`grafana-hardening.env.example`](grafana-hardening.env.example) | No anonymous admin, no default password | [Secure Operational Transparency §7](../SECURE_OPERATIONAL_TRANSPARENCY.md) |
+| [`k8s-securityContext.yaml`](k8s-securityContext.yaml) | Non-root, least-privilege pods; digest-pinned images | [Deployment Provenance & Drift](../DEPLOYMENT_PROVENANCE_AND_DRIFT.md) |
+
+Rename the placeholder env-var and secret names to your project's conventions
+before adopting any of these.

--- a/docs/samples/auth-constants.ts
+++ b/docs/samples/auth-constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared authentication constants.
+ *
+ * Single source of truth for the bcrypt work factor. When hashing cost is
+ * duplicated across call sites it tends to drift (e.g. registration uses one
+ * value, the token hash another). Centralizing it removes the drift and makes a
+ * future cost bump a one-line change. Existing hashes keep verifying because
+ * bcrypt encodes the cost in the hash itself.
+ */
+export const BCRYPT_COST = 12;

--- a/docs/samples/crypto-box.ts
+++ b/docs/samples/crypto-box.ts
@@ -1,0 +1,71 @@
+/**
+ * Authenticated symmetric encryption for secrets at rest (AES-256-GCM).
+ *
+ * Use this to encrypt sensitive material — e.g. TOTP/authenticator seeds — so a
+ * database read alone (leaked backup, injection elsewhere, an over-privileged
+ * job) does not yield usable secrets. Backup/recovery codes should NOT be
+ * encrypted with this; store those only as one-way hashes and show them once.
+ *
+ * Key resolution (lazy, on first use):
+ *   - A 32-byte key (64 hex chars) from an app-encryption env var is used when set.
+ *   - In production the key is REQUIRED — throw rather than fall back.
+ *   - In dev/test a stable key is derived from an existing app secret so local
+ *     flows work without extra configuration. NEVER used in production.
+ *
+ * Sealed format: `${ivBase64}.${tagBase64}.${ctBase64}` — a single string.
+ * Callers can detect sealed-vs-legacy values by the presence of two `.`
+ * separators (see isSealed()), which lets you migrate a column in place.
+ */
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+
+// Rename these to your project's conventions before cascading.
+const APP_ENCRYPTION_KEY_ENV = 'APP_ENCRYPTION_KEY';
+const DEV_FALLBACK_SECRET_ENV = 'APP_SECRET';
+
+let cachedKey: Buffer | null = null;
+
+function resolveKey(): Buffer {
+    if (cachedKey) return cachedKey;
+
+    const hex = process.env[APP_ENCRYPTION_KEY_ENV];
+    if (hex) {
+        const buf = Buffer.from(hex, 'hex');
+        if (buf.length !== 32) {
+            throw new Error(`${APP_ENCRYPTION_KEY_ENV} must be 32 bytes (64 hex characters)`);
+        }
+        cachedKey = buf;
+        return buf;
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+        throw new Error(`${APP_ENCRYPTION_KEY_ENV} is required in production (encrypts secrets at rest)`);
+    }
+
+    // Dev/test only: derive a stable 32-byte key so local flows work without
+    // extra configuration. The production guard above ensures this never runs live.
+    const seed = process.env[DEV_FALLBACK_SECRET_ENV] || 'dev';
+    cachedKey = createHash('sha256').update(`app-enc:${seed}`).digest();
+    return cachedKey;
+}
+
+/** True if `value` is in the sealed `iv.tag.ct` format produced by seal(). */
+export function isSealed(value: string): boolean {
+    return typeof value === 'string' && value.split('.').length === 3;
+}
+
+export function seal(plaintext: string): string {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', resolveKey(), iv);
+    const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return `${iv.toString('base64')}.${tag.toString('base64')}.${ct.toString('base64')}`;
+}
+
+export function open(sealed: string): string {
+    const parts = sealed.split('.');
+    if (parts.length !== 3) throw new Error('Malformed sealed value');
+    const [ivB64, tagB64, ctB64] = parts;
+    const decipher = createDecipheriv('aes-256-gcm', resolveKey(), Buffer.from(ivB64, 'base64'));
+    decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+    return Buffer.concat([decipher.update(Buffer.from(ctB64, 'base64')), decipher.final()]).toString('utf8');
+}

--- a/docs/samples/grafana-hardening.env.example
+++ b/docs/samples/grafana-hardening.env.example
@@ -1,0 +1,26 @@
+# Grafana hardening — safe defaults for an observability stack
+#
+# The failure mode this prevents: an observability dashboard shipped with
+# anonymous access enabled AND a default admin password. Either alone is bad;
+# together, anyone who can reach the service is an admin.
+#
+# Rule: no anonymous access, no default/guessable admin password, and public
+# read-only dashboards (if you want them) are an explicit opt-in — never the
+# fallback.
+
+# Require an operator-supplied password; do NOT provide a baked-in default.
+# Fail the deploy if this is unset rather than defaulting to "admin".
+GF_SECURITY_ADMIN_PASSWORD=__set_me_via_secret__
+
+# Anonymous access OFF by default.
+GF_AUTH_ANONYMOUS_ENABLED=false
+
+# If — and only if — you intentionally publish read-only public dashboards,
+# turn anonymous on with the lowest role and a dedicated, non-default org:
+#   GF_AUTH_ANONYMOUS_ENABLED=true
+#   GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+#   GF_AUTH_ANONYMOUS_ORG_NAME=Public
+# and make sure that org contains ONLY the dashboards you mean to expose.
+
+# Do not allow sign-up, and disable the login form's "help" that leaks version.
+GF_USERS_ALLOW_SIGN_UP=false

--- a/docs/samples/idempotency-key-pattern.md
+++ b/docs/samples/idempotency-key-pattern.md
@@ -1,0 +1,35 @@
+# Exactly-once for money-moving endpoints: the Idempotency-Key pattern
+
+A retried POST must never apply an effect twice. Networks retry; users
+double-click; clients time out and resend. For anything that moves value, "at
+least once" delivery plus a non-idempotent handler equals double-spend.
+
+The pattern (storage-agnostic, opt-in, non-breaking):
+
+1. The client sends an `Idempotency-Key` header (a UUID it generates per logical
+   operation). Callers that don't care about exactly-once simply omit it and the
+   endpoint behaves as before.
+2. The server claims a unique `(user_id, endpoint, key)` record **before**
+   running the operation, using an atomic insert-if-absent (e.g. `INSERT …
+   ON CONFLICT DO NOTHING`, or the equivalent conditional write in your store).
+3. If the claim succeeds, run the operation, then store its response against the
+   key and mark it complete.
+4. If the claim fails (the key already exists), do **not** run the operation —
+   replay the stored response, or return `409` if the first attempt is still in
+   flight.
+
+```
+POST /transfer
+Idempotency-Key: 4f1c…  →  claim (user, endpoint, key)
+                            ├─ new?      run once, store result, return 200
+                            └─ existing? replay stored result (or 409 if pending)
+```
+
+Notes:
+
+- Bind the key to the request body hash so a client reusing a key with a
+  *different* payload is rejected rather than silently replaying the wrong result.
+- If the process dies after the operation commits but before the record is
+  marked complete, leave the key `in_progress` and let a retry get `409` — never
+  a second effect. Reap stale `in_progress` records with a background job.
+- This is a good fit for deposits, transfers, and trade/convert submissions.

--- a/docs/samples/jwt-options.ts
+++ b/docs/samples/jwt-options.ts
@@ -1,0 +1,23 @@
+/**
+ * Centralized JWT algorithm options.
+ *
+ * Pin `algorithms` on every jwt.verify() call so a verifier cannot be steered
+ * into an unexpected algorithm (alg-confusion) or into accepting an unsigned
+ * token (`alg: none`). Signing is symmetric HS256 with a single shared secret;
+ * pinning here makes that guarantee explicit and centralized so it cannot drift
+ * between call sites.
+ *
+ * Cascade note (public lab): keep this as the single import point for JWT
+ * options. If a call site legitimately needs a different (e.g. asymmetric)
+ * algorithm for an external API, give it its own explicit options object rather
+ * than widening this one.
+ */
+import type { SignOptions, VerifyOptions } from 'jsonwebtoken';
+
+export const JWT_ALG = 'HS256' as const;
+export const JWT_VERIFY_OPTS: VerifyOptions = { algorithms: [JWT_ALG] };
+export const JWT_SIGN_OPTS: SignOptions = { algorithm: JWT_ALG };
+
+// Usage:
+//   jwt.sign(payload, SECRET, { ...JWT_SIGN_OPTS, expiresIn: '15m' })
+//   jwt.verify(token, SECRET, JWT_VERIFY_OPTS)

--- a/docs/samples/k8s-securityContext.yaml
+++ b/docs/samples/k8s-securityContext.yaml
@@ -1,0 +1,33 @@
+# Non-root, least-privilege pod/container securityContext for an app workload.
+#
+# Two habits this encodes:
+#   1. Run as a non-root user with a read-only root filesystem and no privilege
+#      escalation — a compromised process gets far less to work with.
+#   2. Pin images by digest, never by a floating tag like :latest. A floating
+#      tag means "whatever that name pointed at when the node happened to pull",
+#      which is neither reproducible nor auditable.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: app
+          # Pin by digest, not by tag. Resolve the digest at release time:
+          #   docker buildx imagetools inspect <registry>/app:<version>
+          image: registry.example.com/app@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          # Give writable scratch as an explicit emptyDir if the app needs /tmp.

--- a/docs/samples/redact-telemetry.ts
+++ b/docs/samples/redact-telemetry.ts
@@ -1,0 +1,19 @@
+/**
+ * Redact directly-identifying values before they are written to a span
+ * attribute (or any telemetry sink). Identifiers such as crypto destination
+ * addresses, emails, or account handles are PII and must not reach a trace
+ * backend — especially one that any public/read-only tooling can query. Keep a
+ * short head/tail for debuggability; fully mask anything too short to redact
+ * meaningfully.
+ *
+ * Apply this at the boundary where client telemetry leaves the authenticated
+ * context, e.g. before setAttribute('...'). Do not rely on display-side
+ * formatters for this — display formatting and telemetry redaction have
+ * different threat models.
+ */
+export function redactForTelemetry(value: string | null | undefined): string {
+    if (!value) return '';
+    const s = String(value);
+    if (s.length <= 12) return '[redacted]';
+    return `${s.slice(0, 6)}...${s.slice(-4)}`;
+}


### PR DESCRIPTION
Publishes the public-safe hardening documentation set produced from the
Krystaline-core review, plus reference samples. Pure documentation — additive,
no application code changes.

**New docs**
- `docs/SECURE_OPERATIONAL_TRANSPARENCY.md` — defensive principles: token
  integrity, two-layer auth throttling, CSPRNG codes, secrets at rest, and a
  read-only / fail-closed public surface.
- `docs/DEPLOYMENT_PROVENANCE_AND_DRIFT.md` — digest pinning, provenance,
  hash-locked dependencies, base-image patching, and drift detection.
- `docs/SECURITY_HARDENING_CHANGELOG.md` — hardening philosophy and a
  public-safe, category-level summary of what we harden.

**Samples** (`docs/samples/`, excluded from the build — reference only)
- `jwt-options.ts`, `auth-constants.ts`, `crypto-box.ts`, `redact-telemetry.ts`,
  `idempotency-key-pattern.md`, `grafana-hardening.env.example`,
  `k8s-securityContext.yaml`, and an index `README.md`.

**Wiring:** added to the README quick links and the public documentation
catalog (`PUBLIC_DOCUMENTS.md`), which already listed these as planned P2 titles.

**Disclosure:** every file is generic patterns and defensive principles only —
no internal thresholds, queue/topology terms, circuit parameters, secret names,
or private hostnames. Verified against the repo's secret and confidential-docs
CI guards, and against the cascade curation memo's scrub list.

Where a sample is already implemented in live code (e.g. telemetry redaction in
`client/src/lib/trace-utils.ts`), that is noted so it isn't wired twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)