### PR TITLE
Fix documentation credibility bugs: broken links, stale numbers, overclaims

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for taking the time to contribute! Please follow these guidelines to keep changes smooth and safe.
 
 ## Getting Started
-- Fork and clone the repo; create a feature branch from `feature/security-review` (or current working branch).
+- Fork and clone the repo; create a feature branch from `develop`.
 - Install dependencies: `npm install --legacy-peer-deps`.
 - Run tests before changes: `npm test` (or targeted suites when applicable).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ naming policy.
 | Destination | Use it for |
 |---|---|
 | [Live Lab](https://www.krystaline.io) | Public demo environment. |
-| [GenAI Observability Solution](docs/GENAI_OBSERVABILITY_SOLUTION.md) | AI SRE thesis, service-manager use case, Core/public boundaries. |
+| [Observability Whitepaper](docs/OBSERVABILITY_WHITEPAPER.md) | Philosophy, architecture, and mathematical foundations of the AI SRE thesis. |
 | [Demo Walkthrough](docs/product/03_DEMO_WALKTHROUGH.md) | Guided 15-minute product tour. |
 | [Getting Started](docs/GETTING_STARTED.md) | Local setup, repo map, and useful commands. |
 | [Architecture](docs/architecture/01_ARCHITECTURE.md) | System design, data flow, and service interactions. |
@@ -42,9 +42,8 @@ naming policy.
 
 ## Status Legend
 
-This README follows the same evidence language as the GenAI observability
-document. It separates what is public, what exists in Core, and what is still a
-roadmap item.
+This README uses the following evidence language. It separates what is public,
+what exists in Core, and what is still a roadmap item.
 
 | Tag | Meaning |
 |---|---|
@@ -146,7 +145,7 @@ operational explanation people can act on.
 | Alerting | Prometheus and Alertmanager rules routed through GoAlert, ntfy, and email paths. |
 | Self-healing | Deterministic escalation ladder for feed recovery and Kubernetes restart behavior. |
 | Cryptographic proof | zk-SNARK trade integrity and solvency-proof concepts connected to traces. |
-| Test posture | 940+ automated tests referenced across the public product and readiness docs. |
+| Test posture | 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server). |
 | Infrastructure | Docker Compose for local development; Helm and Kubernetes assets for deployed environments. |
 
 ## Thesis
@@ -200,7 +199,7 @@ The GenAI observability solution is easiest to understand through the Core
 mission-control dashboards: one surface for GenAI provider health, one for RCA
 reliability, and one for MCP/tool trace coverage.
 
-![GenAI observability dashboard pack: GenAI Operations Core, AI RCA Reliability Matrix, and MCP Signal Lattice](docs/assets/genai-observability-dashboard-pack.png)
+![GenAI observability dashboard pack: GenAI Operations Core, AI RCA Reliability Matrix, and MCP Signal Lattice](docs/blog/assets/genai-observability-dashboard-pack.png)
 
 | Dashboard | Status | What it proves |
 |---|---|---|
@@ -347,7 +346,7 @@ see [Getting Started](docs/GETTING_STARTED.md).
 
 | Guide | Description |
 |---|---|
-| [GenAI Observability Solution](docs/GENAI_OBSERVABILITY_SOLUTION.md) | AI SRE thesis, service-manager control, Core/public status, governance boundaries. |
+| [LLM Monitoring Setup](docs/observability/03_LLM_MONITORING_SETUP.md) | LLM observability, RCA metrics, and monitoring of the AI path itself. |
 | [Brand Positioning](docs/BRAND_POSITIONING.md) | Naming architecture for Krystaline, the lab, Core, and legacy runtime IDs. |
 | [Public Documentation Catalog](docs/PUBLIC_DOCUMENTS.md) | Public-safe document plan, audience map, and redaction boundaries. |
 | [Getting Started](docs/GETTING_STARTED.md) | Local setup and repo orientation. |

--- a/docs/BRAND_POSITIONING.md
+++ b/docs/BRAND_POSITIONING.md
@@ -35,7 +35,8 @@ stakes are high:
 ## Short Description
 
 Krystaline Observability Lab is an open-source crypto and DeFi observability
-demo platform for bleeding-edge OpenTelemetry, AI SRE, proof systems, and
+demo platform for OpenTelemetry-first tracing, statistical and Bayesian anomaly
+reasoning, local-first LLM RCA, and zk-SNARK proof systems, built for
 service-manager operations.
 
 ## One-Liner

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -74,7 +74,7 @@ Point out:
 *Open tab 2: Jaeger. Find the trade's trace.*
 
 ### 4A: Waterfall diagram
-- Show 10–17 spans across services
+- Show the waterfall — typically 17+ spans on the full RabbitMQ trade path (observed in demo traces)
 - Walk through: Kong auth → Express validation → RabbitMQ publish → Matcher processing → wallet update
 - Highlight **W3C Trace Context** propagating through RabbitMQ message headers
 
@@ -85,7 +85,7 @@ Point out:
 
 ### 4C: Grafana correlation
 *Switch to tab 3: Grafana*
-- Show the **Unified Observability Dashboard** (52 panels, 68 PromQL queries)
+- Show the **Unified Observability Dashboard** (73 panels, 79 PromQL query targets)
 - Point to exemplar dots on latency charts — click one to jump to the full trace
 - Show **SLO panel**: 99.9% availability target, error budget remaining, burn rate
 
@@ -107,7 +107,7 @@ Point out:
 - Click **Analyze** — watch the LLM stream in real time
 - Output: `SUMMARY / CAUSES / RECOMMENDATIONS / CONFIDENCE`
 - Llama 3.2:1B, LoRA fine‑tuned on this infrastructure's patterns
-- **Feedback loop**: 👍/👎 ratings → stored as training examples → weekly retraining
+- **Feedback loop**: 👍/👎 ratings → stored as training examples → monthly retraining
 
 > "Two seconds to get a structured root‑cause analysis that would take an SRE 30 minutes."
 
@@ -138,7 +138,7 @@ Point out:
 
 - Show **ZK proof statistics**: total proofs, verification rate, proving time (~200ms)
 - Every trade produces a **Poseidon commitment** binding: price, quantity, user, timestamp, trace ID
-- **Solvency proofs** generated every 60 seconds — reserves ≥ liabilities, verifiable without revealing individual balances
+- **Solvency proofs** generated every 60 seconds — the Groth16 proof is verified server‑side and the public endpoint publishes the Poseidon commitment, without revealing individual balances
 - Public verification API: `GET /api/public/zk/verify/:tradeId`
 
 > "You can verify any trade with 30 lines of JavaScript. No trust required."
@@ -151,7 +151,7 @@ Point out:
 
 Five capabilities no other platform combines:
 
-1. **Distributed tracing** — 17 spans/trade, full W3C context, exemplar correlation
+1. **Distributed tracing** — typically 17+ spans on the full RabbitMQ trade path, full W3C context, exemplar correlation
 2. **Autonomous anomaly detection** — time‑aware baselines, Welford's algorithm, real‑time WebSocket
 3. **AI diagnosis** — fine‑tuned local LLM, continuously improving from operator feedback
 4. **Bayesian inference** — hierarchical probabilistic model for uncertainty‑aware root‑cause ranking
@@ -166,8 +166,8 @@ This is architectural depth, not a feature checklist. 12–18 months to replicat
 | Question | Answer |
 |----------|--------|
 | Is this real data? | Yes — live Binance WebSocket, real order matching, real PostgreSQL. Only starter balance is simulated. |
-| How many spans per trade? | 15–20 with structured business attributes |
-| What if the LLM is wrong? | Confidence levels shown. Bad ratings feed into LoRA fine‑tuning. Model improves weekly. |
+| How many spans per trade? | Typically 17+ on the full RabbitMQ trade path (observed in demo traces), with structured business attributes |
+| What if the LLM is wrong? | Confidence levels shown. Bad ratings feed into LoRA fine‑tuning. Model improves monthly. |
 | Can you fake a ZK proof? | No — Groth16 is cryptographically secure. Verification key is public. |
 | What's your uptime SLA? | 99.9% (43 min error budget/month). Multi‑window burn rate alerting (Google SRE model). |
 | How does this scale? | K8s HPA, OTEL Collector with tail‑based sampling (100% errors, 10% normal), async ZK proofs. |

--- a/docs/MCP_TOP_20_QUESTIONS.md
+++ b/docs/MCP_TOP_20_QUESTIONS.md
@@ -1,5 +1,7 @@
 # OTEL MCP Server — Top 20 Questions It Answers
 
+*Example responses are illustrative transcripts, not live measurements.*
+
 The OTEL MCP Server bridges AI agents to Krystaline's observability stack (Jaeger, Prometheus, Loki) and application APIs (ZK proofs, anomaly detection). It exposes **23 tools** that enable both end‑users and platform engineers to interrogate the system through natural language.
 
 > **Live:** `https://www.krystaline.io` · **MCP endpoint:** `kx-krystalinex-otel-mcp-server:3001`  
@@ -26,7 +28,7 @@ Every trade produces a **Groth16 zk‑SNARK proof** binding price, quantity, use
 
 ### 2. "Is the exchange solvent right now?"
 
-Solvency proofs are generated every 60 seconds, proving reserves ≥ liabilities without revealing individual balances.
+Solvency proofs are generated every 60 seconds — the Groth16 proof is verified server‑side and the public endpoint publishes the Poseidon commitment — without revealing individual balances.
 
 | Tool | What it does |
 |------|-------------|
@@ -109,7 +111,7 @@ The most common on‑call question. The MCP server lets an AI agent correlate tr
 
 ### 7. "What alerts are firing and what do they mean?"
 
-85 alerting rules across 18 groups. The MCP server gives an AI agent the full picture — what's firing, what's pending, and the severity/annotations context.
+48 alerting rules across 11 groups. The MCP server gives an AI agent the full picture — what's firing, what's pending, and the severity/annotations context.
 
 | Tool | What it does |
 |------|-------------|
@@ -214,7 +216,7 @@ Regulatory compliance in crypto means demonstrable auditability. The MCP server 
 
 | Tool | What it does |
 |------|-------------|
-| `zk_solvency` | Proof of reserves ≥ liabilities, generated every 60 seconds |
+| `zk_solvency` | Solvency proof (Groth16, verified server‑side; public Poseidon commitment), generated every 60 seconds |
 | `zk_stats` | Proof generation history — total count, success rate, average proving time |
 | `zk_proof_get` | Individual trade proofs — cryptographic binding of price, quantity, timestamp |
 | `traces_search` | Full audit trail — every API call, every state change, end‑to‑end traced |
@@ -301,14 +303,14 @@ Every step from registration to first trade is instrumented with OpenTelemetry s
 
 | Tool | What it does |
 |------|-------------|
-| `traces_search` | Find traces for each funnel step: registration, KYC, deposit, first order |
+| `traces_search` | Find traces for each funnel step: registration, email verification, first order |
 | `traces_operations` | List all operations per service — see which endpoints are called |
 | `metrics_query` | Request counts per endpoint — compare signup vs deposit vs trade counts |
 | `logs_query` | Error/validation failure logs at each step — why users fail |
 
 **Example:**
 > *"Where's the funnel leaking?"*  
-> → `metrics_query` for request counts at each step → "Last 7 days: 340 registrations → 285 KYC completions (84%) → 142 first deposits (50%) → 98 first trades (69%). Biggest drop: KYC‑to‑deposit. `logs_query` shows 31 deposit attempts failed with 'unsupported currency' — users are trying to deposit EUR but only USD is enabled."
+> → `metrics_query` for request counts at each step → "Last 7 days: 340 registrations → 289 email verifications (85%) → 121 first trades (42%). Biggest drop: verification‑to‑first‑trade. `logs_query` shows 34 order attempts failed validation with 'insufficient balance' — new users are trying to place orders larger than their starter balance."
 
 ---
 

--- a/docs/OBSERVABILITY_WHITEPAPER.md
+++ b/docs/OBSERVABILITY_WHITEPAPER.md
@@ -13,31 +13,32 @@
 
 ## 1. Executive Summary
 
-Krystaline Observability Lab is an institutional-grade cryptocurrency exchange
-observability demo built on a philosophy we call **Proof of Observability™** —
+Krystaline Observability Lab is a full-stack cryptocurrency exchange
+observability demo built on a philosophy we call **Proof of Observability** —
 the principle that every transaction, every service interaction, and every
 system decision must be traced, verified, and auditable in real time.
 
 Unlike traditional exchanges that treat monitoring as an afterthought, the lab
 embeds observability into the architecture from the start. Every trade generates
-a distributed trace spanning 8–15+ microservice operations and a **Groth16
+a distributed trace typically spanning 17+ operations on the full RabbitMQ trade
+path (observed in demo traces) and a **Groth16
 zk-SNARK proof** anchoring execution to its timestamp and OTel trace. Every
 latency measurement feeds into statistical baselines that power autonomous
 anomaly detection. Every security event is persisted, correlated, and surfaced
 through unified dashboards — all without requiring operators to switch between
 disconnected tools.
 
-The result is an exchange platform that doesn't just *claim* uptime — it **proves** it. Continuously. Cryptographically. In real-time.
+The result is an exchange demo that pairs continuous telemetry with cryptographic proof: every filled trade carries a Groth16 integrity proof, and solvency is committed to on a rolling basis.
 This architecture serves as a **scalable template for Unified, Consolidated Observability** — demonstrating how the same patterns can track and trace all operations across an entire organization, from trading to compliance to infrastructure.
 
 **Key metrics:**
 - **4 monitored business services** with 32+ tracked operations  
 - **2 zk-SNARK circuits** (Groth16/BN128) — trade integrity + solvency  
 - **5-tier severity model** (SEV1–SEV5) calibrated to normal distribution percentiles  
-- **34 active alert rules** across 9 categories with automated escalation  
+- **48 alert rules** across 11 groups with automated escalation  
 - **Sub-second anomaly detection** via Welford's online algorithm  
 - **AI-powered root-cause analysis** using LoRA-tuned Llama 3.2:1B (locally hosted)  
-- **940+ automated tests** ensuring regression-free deployments  
+- **1,100+ passing automated tests** (1,088 in the main suite + 99 in otel-mcp-server) ensuring regression-free deployments  
 
 ---
 
@@ -54,9 +55,9 @@ the following core services:
 | **Wallet Service** (`kx-wallet`) | Balance management, transfers, deposits/withdrawals | Node.js + PostgreSQL |
 | **Payment Processor** | Inter-service settlement via message queue | Node.js + RabbitMQ |
 
-The platform processes trades against a **live Binance WebSocket price feed**, ensuring non-simulated, deterministic pricing. Users interact through an institutional-grade React frontend that surfaces real-time system health, trace-verified activity feeds, and per-operation performance data — directly in the trading interface.
+The platform processes trades against a **live Binance WebSocket price feed**, ensuring non-simulated, deterministic pricing. Users interact through a React frontend that surfaces real-time system health, trace-verified activity feeds, and per-operation performance data — directly in the trading interface.
 
-![Krystaline Landing Dashboard — "Don't Trust. Verify." with live system status showing 3,879 trades and all services operational](./images/screenshot_landing_dashboard.png)
+<!-- TODO: recapture screenshot — Krystaline Landing Dashboard — "Don't Trust. Verify." with live system status showing 3,879 trades and all services operational -->
 
 ---
 
@@ -176,25 +177,29 @@ Anomalies are classified into a **5-tier severity model** calibrated to the perc
 
 | Severity | σ Threshold | Percentile | Meaning |
 |----------|-------------|------------|---------|
-| SEV-5 | >1.3σ | ~80th | Minor variance — monitoring only |
-| SEV-4 | >1.65σ | ~90th | Notable deviation — investigate |
-| SEV-3 | >2.0σ | ~95th | Significant anomaly — alert |
-| SEV-2 | >2.6σ | ~99th | Critical — immediate response |
-| SEV-1 | >3.3σ | ~99.9th | Catastrophic — page on-call |
+| SEV-5 | >3.0σ | ~99.9th | Minor variance — monitoring only |
+| SEV-4 | >4.0σ | ~99.997th | Notable deviation — investigate |
+| SEV-3 | >5.0σ | >99.9999th | Significant anomaly — alert |
+| SEV-2 | >6.0σ | >99.9999th | Critical — immediate response |
+| SEV-1 | >8.0σ | >99.9999th | Catastrophic — page on-call |
 
-The system enforces a **minimum sample threshold of 500 observations** before enabling detection, preventing false positives during the bootstrap phase when statistical distributions are unreliable.
+*Source: `server/monitor/anomaly-detector.ts`*
+
+The system enforces a **minimum of 10 samples per baseline bucket (MIN_SAMPLES = 10)** before enabling detection, preventing false positives during the bootstrap phase when statistical distributions are unreliable.
 
 ### 4.2 Transaction Amount Anomaly Detection ("Whale Detector")
 
-A separate **Amount Anomaly Detector** monitors transaction volumes using the same Z-score methodology but with **logarithmically-spaced thresholds** calibrated for financial data spanning 6 orders of magnitude:
+A separate **Amount Anomaly Detector** monitors transaction volumes using the same Z-score methodology but with **a more relaxed threshold ladder (3σ–7σ)** tuned to catch massive outliers in financial data spanning 6 orders of magnitude:
 
 | Severity | σ Threshold | Example Detection |
 |----------|-------------|-------------------|
-| SEV-5 | >1.3σ | Unusually large retail order |
-| SEV-4 | >9.3σ | Large institutional block trade |
-| SEV-3 | >12.0σ | Whale transaction |
-| SEV-2 | >17.2σ | Potential market manipulation |
-| SEV-1 | >20.6σ | Systemic anomaly / 6+ orders of magnitude |
+| SEV-5 | >3.0σ | Unusually large retail order |
+| SEV-4 | >4.0σ | Large institutional block trade |
+| SEV-3 | >5.0σ | Whale transaction |
+| SEV-2 | >6.0σ | Potential market manipulation |
+| SEV-1 | >7.0σ | Systemic anomaly / 6+ orders of magnitude |
+
+*Source: `server/monitor/types.ts` (WHALE_THRESHOLDS)*
 
 This detector is **event-driven** — it evaluates every order and transfer at execution time, providing sub-millisecond detection without polling overhead. It calculates approximate USD values using live price feeds and generates human-readable explanations:
 
@@ -265,13 +270,13 @@ Kong Gateway (HTTP span)
                               └─ PostgreSQL commit
 ```
 
-A single trade generates **8–15+ spans** across 4 services, each with microsecond-precision timing. The **W3C Trace Context** standard (`traceparent` header) ensures lossless propagation through both HTTP and AMQP boundaries.
+A single trade typically generates **17+ spans** on the full RabbitMQ trade path (observed in demo traces), each with microsecond-precision timing. The **W3C Trace Context** standard (`traceparent` header) ensures lossless propagation through both HTTP and AMQP boundaries.
 
 ### 5.2 Trace-Verified Activity Feed
 
 The Activity page surfaces every trade with its associated **Trace ID** — a clickable link that opens the complete distributed trace in Jaeger. This is not cosmetic; the platform **only displays trades for which a valid trace exists**, ensuring every record shown to the user has been verified through the observability pipeline.
 
-![Activity page showing trace-linked transactions — each trade has its Trace ID visible with a "View Trace" button linking to Jaeger](./images/screenshot_activity.png)
+<!-- TODO: recapture screenshot — Activity page showing trace-linked transactions — each trade has its Trace ID visible with a "View Trace" button linking to Jaeger -->
 
 ### 5.3 Cross-Signal Correlation
 
@@ -380,7 +385,7 @@ The base Llama 3.2:1B model can be **continuously improved** using production da
 |-----------|-------|
 | **Framework** | Axolotl + QLoRA (4-bit quantization) |
 | **Base model** | Llama 3.2:1B |
-| **Adapter** | LoRA rank 32, alpha 64, dropout 0.05 |
+| **Adapter** | LoRA rank 16, alpha 32, dropout 0.05 |
 | **Training data** | Human-validated anomaly analyses (accept/reject + freeform corrections) |
 | **Data source** | `GET /api/v1/monitor/training-data` — exports validated analyses in Axolotl JSONL format |
 | **Human feedback** | Operators rate AI analyses via the dashboard; corrections become training samples |
@@ -477,23 +482,23 @@ All four observability pillars converge in a single **Grafana dashboard** that p
 | **Database Health** | PostgreSQL Exporter | Connection pool, query duration, table size |
 | **Message Queue** | RabbitMQ (Prometheus) | Queue depth, consumer lag, publish rate |
 
-![Krystaline Unified Observability dashboard — Application Metrics section showing HTTP Request Rate, Response Latency (P50/P95), Error Rate, and Server Memory utilization](./images/screenshot_grafana_1_metrics.png)
+<!-- TODO: recapture screenshot — Krystaline Unified Observability dashboard — Application Metrics section showing HTTP Request Rate, Response Latency (P50/P95), Error Rate, and Server Memory utilization -->
 
-![Order Matcher section showing 475 orders processed, order processing rate, P50/P95 matcher latency, 0.242% average slippage, and System Health panels (CPU 34.6%, Memory 59.7%, Disk 60.0%, 7 Services Up)](./images/screenshot_grafana_2_orders.png)
+<!-- TODO: recapture screenshot — Order Matcher section showing 475 orders processed, order processing rate, P50/P95 matcher latency, 0.242% average slippage, and System Health panels (CPU 34.6%, Memory 59.7%, Disk 60.0%, 7 Services Up) -->
 
-![Logs & Traces section showing aggregated Application Logs from the OTEL Collector and Recent Traces panel for distributed trace analysis](./images/screenshot_grafana_3_logs.png)
+<!-- TODO: recapture screenshot — Logs & Traces section showing aggregated Application Logs from the OTEL Collector and Recent Traces panel for distributed trace analysis -->
 
 #### Jaeger Distributed Trace Backend
 
 The Jaeger UI provides deep-dive trace analysis with service-level span breakdowns, latency scatter plots, and cross-service dependency graphs:
 
-![Jaeger UI showing 20 distributed traces from api-gateway (Kong) — traces contain 30–32 spans across 3 services (api-gateway, kx-exchange, kx-matcher) with 130–240ms durations, demonstrating full end-to-end trace propagation through the order processing pipeline](./images/screenshot_jaeger.png)
+<!-- TODO: recapture screenshot — Jaeger UI showing 20 distributed traces from api-gateway (Kong) — traces contain 30–32 spans across 3 services (api-gateway, kx-exchange, kx-matcher) with 130–240ms durations, demonstrating full end-to-end trace propagation through the order processing pipeline -->
 
 ### 8.2 Public Transparency Dashboard
 
 Beyond internal monitoring, Krystaline exposes a **customer-facing transparency page** that displays real-time system health metrics directly within the trading application:
 
-![System Transparency page — 4 active services monitored, 99.9% uptime, 397ms average response, 32 operations tracked, with per-service health cards showing individual response times](./images/screenshot_transparency.png)
+<!-- TODO: recapture screenshot — System Transparency page — 4 active services monitored, 99.9% uptime, 397ms average response, 32 operations tracked, with per-service health cards showing individual response times -->
 
 This is not a static status page — it's a **live observability feed** that recalculates from actual trace data every refresh. Each service card shows:
 - Current average response time (from Jaeger spans, not synthetic probes)
@@ -506,7 +511,7 @@ Alerts flow through a multi-tier escalation pipeline:
 
 ```mermaid
 flowchart LR
-    PR[Prometheus Rules<br/>25+ rules] --> AM[Alertmanager]
+    PR[Prometheus Rules<br/>48 rules] --> AM[Alertmanager]
     
     AM -->|"severity: critical"| GC[GoAlert Critical<br/>+ Email + ntfy]
     AM -->|"severity: warning"| GW[GoAlert Warning<br/>batched 1 min]
@@ -544,7 +549,7 @@ Krystaline defines and monitors two primary SLOs:
 
 ### 9.2 Minimizing MTTD (Mean Time to Detect)
 
-The platform achieves near-zero MTTD through multiple detection layers:
+The platform targets fast detection — including a 10-second anomaly detection loop — through multiple detection layers:
 
 | Detection Layer | Polling Interval | MTTD |
 |----------------|-----------------|------|
@@ -556,17 +561,17 @@ The platform achieves near-zero MTTD through multiple detection layers:
 
 ### 9.3 Minimizing MTTR (Mean Time to Resolve)
 
-The AI-powered analysis pipeline dramatically reduces MTTR by automating the most time-consuming phase of incident response — **diagnosis**:
+The AI-powered analysis pipeline shortens triage by automating the most time-consuming phase of incident response — **diagnosis**:
 
-| MTTR Phase | Traditional | Krystaline | Improvement |
-|------------|-----------|-------------|-------------|
-| **Detection** | 5–15 min (manual) | <60s (automated) | ~10× faster |
-| **Triage** | 10–30 min (severity assessment) | Instant (5-tier auto-classification) | Eliminated |
-| **Diagnosis** | 30–120 min (log correlation) | 2–5s (LLM analysis with context) | ~100× faster |
-| **Notification** | 5–15 min (manual paging) | 10–30s (GoAlert auto-escalation) | ~20× faster |
-| **Resolution** | Variable | Variable + guided recommendations | Accelerated |
+| MTTR Phase | Krystaline |
+|------------|-------------|
+| **Detection** | <60s (automated) |
+| **Triage** | Instant (5-tier auto-classification) |
+| **Diagnosis** | 2–5s (LLM analysis with context) |
+| **Notification** | 10–30s (GoAlert auto-escalation) |
+| **Resolution** | Variable + guided recommendations |
 
-The combination of automated detection, instant severity classification, AI-generated root-cause analysis, and tiered escalation reduces the theoretical MTTR from **60–180 minutes** to **under 10 minutes** for most incident categories.
+The combination of automated detection, instant severity classification, AI-generated root-cause analysis, and tiered escalation shortens triage for most incident categories.
 
 ---
 
@@ -576,7 +581,7 @@ The combination of automated detection, instant severity classification, AI-gene
 
 The trading interface integrates observability directly into the user workflow. The **Trade page** shows live traces and portfolio data side-by-side:
 
-![Trade page with BTC/USD trading interface, portfolio summary, and Live Traces panel linking to Jaeger and the monitoring dashboard](./images/screenshot_trade_page.png)
+<!-- TODO: recapture screenshot — Trade page with BTC/USD trading interface, portfolio summary, and Live Traces panel linking to Jaeger and the monitoring dashboard -->
 
 The **Live Traces** panel at the bottom-right is a WebSocket-powered stream of OpenTelemetry trace data. When a user executes a trade, the trace appears in real-time — providing instant confirmation that the operation was captured, measured, and verified by the observability pipeline.
 
@@ -640,7 +645,7 @@ The `trade_integrity.circom` circuit proves that a trade commitment was computed
 
 ### 11.3 Solvency Circuit
 
-A separate circuit proves platform solvency every 60 seconds without revealing individual balances:
+A separate circuit generates a solvency proof every 60 seconds without revealing individual balances. The Poseidon reserve commitment is published on the public endpoint; the Groth16 solvency proof itself is verified server-side (the trade-integrity proofs are the externally verifiable ones):
 
 - **8-balance Poseidon commitment**: `Poseidon(balance₁, ..., balance₈) == reserveCommitment`
 - **Sum constraint**: `SUM(balances) == claimedTotal`
@@ -668,7 +673,7 @@ This means **the cryptographic layer itself is observable** — proving time, ve
 
 ### 12.1 Container Architecture
 
-The platform runs as a Docker Compose stack with 18 containerized services:
+The platform runs as a Docker Compose stack with 22 services in docker-compose.yml:
 
 | Category | Services | Count |
 |----------|----------|-------|
@@ -696,18 +701,20 @@ The platform includes a complete **Helm chart** and Kubernetes manifests for pro
 
 ## Appendix A: Alert Rules Summary
 
-| Category | Alert Count | Key Rules |
+| Group | Alert Count | Key Rules |
 |----------|------------|-----------|
-| Application | 4 | HighErrorRate, HighLatencyP99, HighLatencyP99Critical, NoTraffic |
-| Trading | 3 | OrderProcessingFailures, OrderQueueBacklog, PriceFeedUnavailable |
-| Database | 4 | PostgreSQLDown, ConnectionPoolExhaustion, SlowQueries, DatabaseSizeLarge |
-| RabbitMQ | 3 | RabbitMQDown, HighMessageBacklog, ConsumerLag |
-| Infrastructure | 3 | HighCPUUsage, HighMemoryUsage, DiskSpaceLow/Critical |
+| Application | 5 | HighErrorRate, HighLatencyP99, HighLatencyP99Critical, ServiceDown, … |
+| Trading | 4 | OrderProcessingFailures, OrderQueueBackup, OrderQueueCritical, PriceFeedUnavailable |
+| Database | 5 | PostgreSQLDown, DatabaseConnectionsHigh, DatabaseConnectionsCritical, SlowQueries, … |
+| RabbitMQ | 4 | RabbitMQDown, RabbitMQHighMemory, RabbitMQNoConsumers, RabbitMQConsumerLag |
+| Infrastructure | 4 | HighCPUUsage, HighMemoryUsage, DiskSpaceLow, DiskSpaceCritical |
 | Resilience | 2 | CircuitBreakerOpen, CircuitBreakerHalfOpen |
-| Security | 9 | BruteForce, CredentialStuffing, 2FABypass, RateLimitAbuse, etc. |
-| Traffic | 4 | TrafficSpike, SustainedHighTraffic, TrafficFlood, UnusualErrorSpike |
-| SLA | 2 | AvailabilitySLABreach, LatencySLAAtRisk |
-| **Total** | **34** | |
+| Security | 10 | AuthenticationFailures, BruteForceAttack, CredentialStuffingAttack, RateLimitAbuse, … |
+| SLO Availability | 4 | SLOAvailabilityBurnRateCritical/High/Elevated/Slow (multi-window burn rates) |
+| SLO Latency | 2 | SLOLatencyBurnRateCritical, SLOLatencyBurnRateHigh |
+| Redis | 4 | RedisDown, RedisMemoryHigh, RedisConnectedClientsHigh, RedisKeyEviction |
+| Container Health | 4 | ContainerCrashLooping, ContainerOOMKilled, PodNotReady, DeploymentReplicasMismatch |
+| **Total** | **48** | Source: `config/alerting-rules.yml` (11 groups) |
 
 ## Appendix B: Prometheus Metrics Catalog
 

--- a/docs/PUBLIC_DOCUMENTS.md
+++ b/docs/PUBLIC_DOCUMENTS.md
@@ -15,7 +15,7 @@ and security-sensitive runbooks private.
 |---|---|---|---|---|
 | P0 | Brand positioning | Contributors, observability leaders, service managers | How Krystaline, Krystaline Observability Lab, Krystaline Core, AI SRE, and Proof of Observability fit together | Naming migration details that reveal private systems, unreleased product names, customer-specific positioning |
 | P0 | Proof of Observability overview | Users, operators, investors | Why an exchange should prove trades, health, and latency with live telemetry instead of status-page claims | Internal dashboards with sensitive labels, exact alert expressions, private environment details |
-| P0 | GenAI observability solution | Observability experts, service managers, senior technical leadership | Thesis, dashboard evidence pack, status map, and AI SRE story for service-manager RCA over verified telemetry | Exact prompts, private context-builder internals, model weights, provider credentials, incident history |
+| P0 | Observability whitepaper (published as `docs/OBSERVABILITY_WHITEPAPER.md`) | Observability experts, service managers, senior technical leadership | Thesis, dashboard evidence pack, status map, and AI SRE story for service-manager RCA over verified telemetry | Exact prompts, private context-builder internals, model weights, provider credentials, incident history |
 | P0 | Public MCP transparency guide | AI-agent builders, users, developers | How Claude, ChatGPT, Copilot, Cursor, or other MCP clients can query public exchange health, volume, recent trades, trace summaries, and ZK proof status | Personal-account tools, private logs, internal MCP auth, raw user data |
 | P0 | From Observability to Integrity | Crypto researchers, users, auditors | How OpenTelemetry and zero-knowledge proofs complement each other: traces show behavior; proofs show integrity | Circuit source, proving keys, exact witness construction, performance bottlenecks that could aid abuse |
 | P0 | Trace-verified trade lifecycle | Developers, prospective users | A conceptual walkthrough of a trade moving through gateway, exchange, matcher, settlement, trace, and public verification | Queue topology details, database schema internals, operational credentials |
@@ -34,7 +34,7 @@ and security-sensitive runbooks private.
 ## Suggested Public Doc Order
 
 1. Publish the flagship narrative: **Proof of Observability overview**.
-2. Publish the technical leadership narrative: **GenAI observability solution**.
+2. Publish the technical leadership narrative: **Observability whitepaper** (`docs/OBSERVABILITY_WHITEPAPER.md`).
 3. Publish the hands-on trust surface: **Public MCP transparency guide**.
 4. Publish the cryptographic trust story: **From Observability to Integrity**.
 5. Publish the operational story: **AI SRE concept note** and **adaptive anomaly detection explainer**.

--- a/docs/architecture/02_EXTERNAL_SERVICES.md
+++ b/docs/architecture/02_EXTERNAL_SERVICES.md
@@ -25,8 +25,8 @@ curl http://localhost:16686        # Jaeger UI
 - **Manager UI**: http://localhost:8002
 
 ### RabbitMQ
-- **AMQP**: amqp://admin:admin123@localhost:5672
-- **Management UI**: http://localhost:15672 (admin/admin123)
+- **AMQP**: amqp://admin:<RABBITMQ_PASSWORD>@localhost:5672
+- **Management UI**: http://localhost:15672 (admin / <see RABBITMQ_PASSWORD in your env>)
 
 ### Jaeger (Optional)
 - **UI**: http://localhost:16686
@@ -43,7 +43,7 @@ KONG_GATEWAY_URL=http://localhost:8000
 KONG_ADMIN_URL=http://localhost:8001
 
 # RabbitMQ Configuration
-RABBITMQ_URL=amqp://admin:admin123@localhost:5672
+RABBITMQ_URL=amqp://admin:<RABBITMQ_PASSWORD>@localhost:5672
 
 # Jaeger (Optional)
 JAEGER_ENDPOINT=http://localhost:4318/v1/traces
@@ -97,7 +97,7 @@ docker-compose -f docker-compose.external.yml down -v
 
 ### RabbitMQ Connection Failed
 - Check if port 5672 is free
-- Verify credentials: admin/admin123
+- Verify credentials: admin / <see RABBITMQ_PASSWORD in your env>
 
 ### No Traces in Jaeger
 - Ensure JAEGER_ENDPOINT is configured

--- a/docs/architecture/04_TECHNICAL_ASSESSMENT.md
+++ b/docs/architecture/04_TECHNICAL_ASSESSMENT.md
@@ -7,7 +7,7 @@
 
 ## Executive Summary
 
-Krystaline is a **demo-ready crypto exchange platform** with exceptional observability, security, and monitoring capabilities. The backend demonstrates professional-grade engineering with extensive test coverage (931 tests), proper security middleware, and a sophisticated anomaly detection system. The frontend requires polish for production but is sufficient for investor demos.
+Krystaline is a **demo-ready crypto exchange platform** with exceptional observability, security, and monitoring capabilities. The backend demonstrates professional-grade engineering with extensive test coverage (1,100+ passing automated tests: 1,088 in the main suite + 99 in otel-mcp-server), proper security middleware, and a sophisticated anomaly detection system. The frontend requires polish for production but is sufficient for investor demos.
 
 ### Overall Health Score: **83/100**
 
@@ -62,17 +62,17 @@ Krystaline is a **demo-ready crypto exchange platform** with exceptional observa
 ## Security Assessment
 
 ### ✅ Rate Limiting (IMPLEMENTED)
-**Location:** [server/middleware/security.ts](../server/middleware/security.ts)
+**Location:** [server/middleware/security.ts](../../server/middleware/security.ts)
 
 ```typescript
 // Three-tier rate limiting system
-generalRateLimiter    // 100 req/min - General API
-authRateLimiter       // 20 req/min  - Authentication
-sensitiveRateLimiter  // 5 req/min   - Password reset, etc.
+generalRateLimiter    // 300 req/min - General API
+authRateLimiter       // 60 req/min  - Authentication
+sensitiveRateLimiter  // 15 req/min  - Password reset, etc.
 ```
 
 ### ✅ Security Headers (IMPLEMENTED)
-**Location:** [server/middleware/security.ts](../server/middleware/security.ts)
+**Location:** [server/middleware/security.ts](../../server/middleware/security.ts)
 
 Helmet configured with:
 - Content Security Policy (CSP)
@@ -83,7 +83,7 @@ Helmet configured with:
 - Strict referrer policy
 
 ### ✅ Password Security (IMPLEMENTED)
-**Location:** [server/auth/auth-service.ts](../server/auth/auth-service.ts)
+**Location:** [server/auth/auth-service.ts](../../server/auth/auth-service.ts)
 
 - **Algorithm:** bcrypt
 - **Cost Factor:** 12 (secure)
@@ -96,7 +96,7 @@ Helmet configured with:
 - Email verification flow with 6-digit codes
 
 ### ✅ CORS (IMPLEMENTED)
-**Location:** [server/middleware/security.ts](../server/middleware/security.ts)
+**Location:** [server/middleware/security.ts](../../server/middleware/security.ts)
 
 - Environment-aware origins
 - Proper preflight handling
@@ -111,7 +111,7 @@ Helmet configured with:
 
 ### Testing Assessment
 
-### Test Results: not rerun on 2026-02-06 (last verified: 712/714 passing)
+### Test Results: 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server)
 
 | Test Category | Files | Tests | Status |
 |---------------|-------|-------|--------|
@@ -161,7 +161,7 @@ server/
 ```
 
 ### ✅ Health Endpoints (IMPLEMENTED)
-**Location:** [server/api/health-routes.ts](../server/api/health-routes.ts)
+**Location:** [server/api/health-routes.ts](../../server/api/health-routes.ts)
 
 | Endpoint | Purpose | Status |
 |----------|---------|--------|
@@ -169,7 +169,7 @@ server/
 | `GET /ready` | Readiness probe (with dependency checks) | ✅ |
 
 ### ✅ Graceful Shutdown (IMPLEMENTED)
-**Location:** [server/index.ts](../server/index.ts#L170)
+**Location:** [server/index.ts](../../server/index.ts#L170)
 
 - SIGTERM/SIGINT handlers
 - Database connection cleanup
@@ -177,7 +177,7 @@ server/
 - Active request draining
 
 ### ✅ Error Handling (IMPLEMENTED)
-**Location:** [server/middleware/error-handler.ts](../server/middleware/error-handler.ts)
+**Location:** [server/middleware/error-handler.ts](../../server/middleware/error-handler.ts)
 
 - Global error handler
 - AppError class hierarchy
@@ -186,7 +186,7 @@ server/
 - Correlation ID tracking
 
 ### ✅ Configuration Management (IMPLEMENTED)
-**Location:** [server/config/index.ts](../server/config/index.ts)
+**Location:** [server/config/index.ts](../../server/config/index.ts)
 
 - Centralized Zod-validated config
 - Environment variable mapping
@@ -197,21 +197,21 @@ server/
 ## Observability Assessment
 
 ### ✅ Distributed Tracing
-**Location:** [server/otel.ts](../server/otel.ts)
+**Location:** [server/otel.ts](../../server/otel.ts)
 
 - Full OpenTelemetry SDK integration with auto-instrumentation (Express, HTTP, pg, amqplib)
 - Jaeger exporter enabled; browser context propagation; Kong spans correlated across gateway paths
 - Note: unify exporters under OTLP endpoint once Unified Observability Mode is enabled
 
 ### ✅ Metrics Collection
-**Location:** [server/metrics/prometheus.ts](../server/metrics/prometheus.ts)
+**Location:** [server/metrics/prometheus.ts](../../server/metrics/prometheus.ts)
 
 - HTTP RED metrics, active connections, order processing histograms, circuit breaker gauges
 - RabbitMQ queue depth gauges; business KPIs (trade volume/value, logins, active users)
 - Next step: attach exemplars using active trace IDs for cross-signal linking
 
 ### ✅ Anomaly Detection
-**Location:** [server/monitor/](../server/monitor/)
+**Location:** [server/monitor/](../../server/monitor/)
 
 | Component | Purpose | Status |
 |-----------|---------|--------|
@@ -230,7 +230,7 @@ Features:
 - Prometheus metric correlation
 
 ### ✅ Structured Logging
-**Location:** [server/lib/logger.ts](../server/lib/logger.ts)
+**Location:** [server/lib/logger.ts](../../server/lib/logger.ts)
 
 - Pino JSON with correlation IDs and request/response logging
 - Plan: add OTLP log exporter and align fields with trace/metric resource attributes
@@ -359,7 +359,7 @@ Features:
 ## Database Assessment
 
 ### Schema (IMPLEMENTED)
-**Location:** [db/init.sql](../db/init.sql)
+**Location:** [db/init.sql](../../db/init.sql)
 
 | Table | Purpose | Status |
 |-------|---------|--------|
@@ -382,7 +382,7 @@ Features:
 
 ## Infrastructure Assessment
 
-### Docker Services (14 containers)
+### Docker Services (22 services)
 | Service | Image | Ports | Status |
 |---------|-------|-------|--------|
 | kong-gateway | kong/kong-gateway | 8000-8003 | ✅ |
@@ -432,7 +432,7 @@ Krystaline has a **rock-solid backend** with exceptional observability—the cor
 
 ### Strengths
 1. **Production-grade security** - Rate limiting, helmet, bcrypt, JWT
-2. **Comprehensive testing** - 931 tests with isolated mocking
+2. **Comprehensive testing** - 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server) with isolated mocking
 3. **Best-in-class observability** - Full OTEL stack with LLM analysis
 4. **Clean architecture** - Clear separation of concerns
 5. **Real market data** - Binance WebSocket integration
@@ -458,7 +458,7 @@ Krystaline has a **rock-solid backend** with exceptional observability—the cor
 - Empty states (pre-seed data recommended)
 
 **Recommended prep:**
-1. Run through [DEMO-WALKTHROUGH.md](./DEMO-WALKTHROUGH.md)
+1. Run through [DEMO-WALKTHROUGH.md](../product/03_DEMO_WALKTHROUGH.md)
 2. Pre-seed demo trades
 3. Practice the Jaeger reveal moment
 4. Have fallback talking points ready

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -11,7 +11,6 @@ current public documentation surface.
 The active public docs live one level up in `docs/` and in the curated
 subfolders:
 
-- `docs/GENAI_OBSERVABILITY_SOLUTION.md`
 - `docs/BRAND_POSITIONING.md`
 - `docs/PUBLIC_DOCUMENTS.md`
 - `docs/GETTING_STARTED.md`
@@ -21,13 +20,16 @@ subfolders:
 - `docs/operations/`
 - `docs/product/`
 
+The earlier `docs/GENAI_OBSERVABILITY_SOLUTION.md` draft was removed from the
+repo; it is superseded by `docs/OBSERVABILITY_WHITEPAPER.md`.
+
 ## Archived Files
 
 | File | Why it is archived |
 |---|---|
 | `legacy-dashboard-reliability-notes.md` | Rough notes that fed later dashboard-integrity thinking. |
 | `legacy-mcp-top-10-duplicate.md` | Duplicate of the current Top 20 MCP questions guide, including the same internal title. |
-| `legacy-mlops-for-aiops.md` | Older standalone LoRA/MLOps draft now superseded by the GenAI observability solution and fine-tuning guide. |
+| `legacy-mlops-for-aiops.md` | Older standalone LoRA/MLOps draft now superseded by the observability whitepaper and fine-tuning guide. |
 | `legacy-observability-gap-closure-plan.md` | Large internal planning analysis, useful as historical context but too detailed for the public landing surface. |
 | `legacy-phase3-circuit-spec.md` | Older circuit-phase spec now covered at a higher level in the observability whitepaper and proof docs. |
 | `legacy-placeholder-test2.md` | Scratch placeholder retained only for history. |

--- a/docs/blog/ai-ops-2026-article-with-practical-case-and-appendix.md
+++ b/docs/blog/ai-ops-2026-article-with-practical-case-and-appendix.md
@@ -368,4 +368,4 @@ In one sentence: the standard defines the contract, the gateway exposes live evi
 - OpenTelemetry: [Semantic conventions for generative AI metrics](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/)
 - OpenTelemetry: [Semantic conventions for generative client AI spans](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)
 - OpenTelemetry: [Semantic conventions for Model Context Protocol (MCP)](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/)
-- Krystaline Observability Lab: [GenAI Observability Solution](../GENAI_OBSERVABILITY_SOLUTION.md)
+- Krystaline Observability Lab: [Observability Whitepaper](../OBSERVABILITY_WHITEPAPER.md)

--- a/docs/observability/01_OTEL_TRACING_GUIDE.md
+++ b/docs/observability/01_OTEL_TRACING_GUIDE.md
@@ -65,9 +65,6 @@ flowchart LR
     OC --> J
 ```
 
-
-
-> Note: SVG is available at `docs/images/trace-hierarchy.svg` if you prefer vector images.
 ---
 
 ## Critical: How Spans Join Into Hierarchy
@@ -93,7 +90,7 @@ traceparent: 00-{traceId}-{spanId}-{flags}
              └── version
 ```
 
-### Implementation: [client/src/lib/tracing.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/client/src/lib/tracing.ts)
+### Implementation: [client/src/lib/tracing.ts](../../client/src/lib/tracing.ts)
 
 ```typescript
 import { v4 as uuidv4 } from 'uuid';
@@ -125,7 +122,7 @@ This is used when making API calls from the browser to establish the **root span
 
 Kong receives the `traceparent` header and propagates it downstream.
 
-### Plugin Configuration: [scripts/enable-kong-otel.js](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/scripts/enable-kong-otel.js)
+### Plugin Configuration: [scripts/enable-kong-otel.js](../../scripts/enable-kong-otel.js)
 
 ```javascript
 const pluginConfig = {
@@ -152,7 +149,7 @@ const pluginConfig = {
 
 ## 3. Node.js SDK: Automatic HTTP Propagation
 
-### Instrumentation Setup: [server/instrumentation.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/instrumentation.ts)
+### Instrumentation Setup: [server/otel.ts](../../server/otel.ts)
 
 ```typescript
 import { NodeSDK } from '@opentelemetry/sdk-node';
@@ -189,7 +186,7 @@ When an HTTP request arrives with `traceparent`:
 
 ## 4. RabbitMQ Producer: Manual Context Injection
 
-### Implementation: [server/services/rabbitmq-client.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/services/rabbitmq-client.ts)
+### Implementation: [server/services/rabbitmq-client.ts](../../server/services/rabbitmq-client.ts)
 
 ```typescript
 import { trace, context, SpanKind, propagation } from '@opentelemetry/api';
@@ -248,7 +245,7 @@ async publishOrder(order: Order): Promise<Response> {
 
 ## 5. RabbitMQ Consumer: Context Extraction
 
-### Implementation: [payment-processor/index.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/payment-processor/index.ts)
+### Implementation: [payment-processor/index.ts](../../payment-processor/index.ts)
 
 ```typescript
 import { trace, context, SpanKind, propagation } from '@opentelemetry/api';
@@ -324,7 +321,7 @@ flowchart TD
 
 ## 7. CORS Headers for Trace Context
 
-### Server Configuration: [server/index.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/index.ts)
+### Server Configuration: [server/index.ts](../../server/index.ts)
 
 ```typescript
 app.use((req, res, next) => {
@@ -436,11 +433,11 @@ tracer.startSpan('name', { kind: SpanKind.CONSUMER }, ctx);
 
 | File | Purpose |
 |------|---------|
-| [instrumentation.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/instrumentation.ts) | SDK initialization |
-| [rabbitmq-client.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/services/rabbitmq-client.ts) | RabbitMQ context injection |
-| [payment-processor/index.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/payment-processor/index.ts) | RabbitMQ context extraction |
-| [tracing.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/client/src/lib/tracing.ts) | Client trace ID generation |
-| [enable-kong-otel.js](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/scripts/enable-kong-otel.js) | Kong plugin configuration |
+| [otel.ts](../../server/otel.ts) | SDK initialization |
+| [rabbitmq-client.ts](../../server/services/rabbitmq-client.ts) | RabbitMQ context injection |
+| [payment-processor/index.ts](../../payment-processor/index.ts) | RabbitMQ context extraction |
+| [tracing.ts](../../client/src/lib/tracing.ts) | Client trace ID generation |
+| [enable-kong-otel.js](../../scripts/enable-kong-otel.js) | Kong plugin configuration |
 
 ---
 
@@ -487,6 +484,4 @@ Expected output should show:
 
 ### Proper Trace Hierarchy
 
-When context propagation is working correctly, traces show a clean parent-child hierarchy with all services connected:
-
-![Proper trace hierarchy with api-gateway as parent of kx-exchange](images/proper-trace-hierarchy.png)
+When context propagation is working correctly, traces show a clean parent-child hierarchy with all services connected.

--- a/docs/observability/02_ANOMALY_DETECTION_DESIGN.md
+++ b/docs/observability/02_ANOMALY_DETECTION_DESIGN.md
@@ -32,9 +32,6 @@ flowchart TD
     P --> L
 ```
 
-
-> Note: SVG is available at `docs/images/baseline-calculation.svg` if you prefer vector images.
-
 ---
 
 ## 1. Time Bucketing Strategy
@@ -59,7 +56,7 @@ const bucketKey = `${spanKey}:${dayOfWeek}:${hourOfDay}`;
 
 ## 2. Baseline Calculation
 
-### Data Source: [baseline-calculator.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/monitor/baseline-calculator.ts)
+### Data Source: [baseline-calculator.ts](../../server/monitor/baseline-calculator.ts)
 
 ```typescript
 // Query 30 days of historical data
@@ -131,7 +128,7 @@ const thresholds = {
 
 ## 4. Severity Classification (SEV 1-5)
 
-### Types: [types.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/monitor/types.ts)
+### Types: [types.ts](../../server/monitor/types.ts)
 
 ```typescript
 export type SeverityLevel = 1 | 2 | 3 | 4 | 5;

--- a/docs/observability/03_LLM_MONITORING_SETUP.md
+++ b/docs/observability/03_LLM_MONITORING_SETUP.md
@@ -22,12 +22,12 @@ flowchart LR
 ```
 
 **Key Files:**
-- [ws-server.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/monitor/ws-server.ts) - WebSocket server
-- [stream-analyzer.ts](file:///c:/Users/bizai/Documents/GitHub/OtelE2E/server/monitor/stream-analyzer.ts) - Batching + streaming
+- [ws-server.ts](../../server/monitor/ws-server.ts) - WebSocket server
+- [stream-analyzer.ts](../../server/monitor/stream-analyzer.ts) - Batching + streaming
 
 **Features:**
 - 30-second batch window
-- 8 use-case detection patterns (P0/P1/P2)
+- 9 use-case detection patterns (P0/P1/P2)
 - Streaming tokens to UI
 - Auto-reconnecting WebSocket client
 

--- a/docs/operations/02_DEPLOYMENT_K8S.md
+++ b/docs/operations/02_DEPLOYMENT_K8S.md
@@ -10,7 +10,7 @@
 - Kubernetes cluster (Docker Desktop, Minikube, or cloud-managed)
 - Helm 3.x installed
 - kubectl configured for your cluster
-- Container registry access (default: `bizait-nas:5000`)
+- Container registry access (default: `<your-registry>`)
 
 ---
 
@@ -93,7 +93,7 @@ k8s/charts/krystalinex/
 server:
   replicaCount: 1          # Scale up for production
   image:
-    repository: bizait-nas:5000/krystalinex/server
+    repository: <your-registry>/krystalinex/server
     tag: v1.0.9
   autoscaling:
     enabled: false         # Enable for production

--- a/docs/operations/03_BACKUP_RESTORE.md
+++ b/docs/operations/03_BACKUP_RESTORE.md
@@ -300,7 +300,7 @@ Write-Host "✅ Backup completed at $(Get-Date)"
 ```powershell
 # Create scheduled task for automated backups every 6 hours
 $action = New-ScheduledTaskAction -Execute "pwsh.exe" `
-    -Argument "-File C:\Users\bizai\Documents\GitHub\Krystaline\scripts\backup-databases.ps1"
+    -Argument "-File <path-to-repo>\scripts\backup-databases.ps1"
 
 $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Hours 6)
 

--- a/docs/operations/04_RUNBOOK.md
+++ b/docs/operations/04_RUNBOOK.md
@@ -675,7 +675,7 @@ curl -X POST "https://ntfy.sh/YOUR_TOPIC" \
 
 Alerts automatically flow: **Prometheus** → **Alertmanager** → **GoAlert** + **ntfy**
 
-Critical alerts are sent to both GoAlert and ntfy for redundancy. See [config/alertmanager.yml](../config/alertmanager.yml).
+Critical alerts are sent to both GoAlert and ntfy for redundancy. See [config/alertmanager.yml](../../config/alertmanager.yml).
 
 ### Troubleshooting ntfy
 

--- a/docs/operations/05_PRODUCTION_READINESS_ASSESSMENT.md
+++ b/docs/operations/05_PRODUCTION_READINESS_ASSESSMENT.md
@@ -51,7 +51,7 @@
 ### 1.3 API Security ✅
 | Check | Status | Notes |
 |-------|--------|-------|
-| Rate limiting | ✅ Pass | 3-tier (general: 300/min, auth: 60/min, order: 30/min) |
+| Rate limiting | ✅ Pass | 3-tier (general: 300/min, auth: 60/min, sensitive: 15/min) |
 | Security headers (Helmet) | ✅ Pass | CSP, XSS filter, no-sniff, frame-guard |
 | CORS configuration | ✅ Pass | Whitelist-based, environment-specific |
 | Request sanitization | ✅ Pass | Sensitive fields redacted in logs |
@@ -70,8 +70,8 @@
 ### 2.1 Test Coverage ✅
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
-| Unit test suites | 43 | 40+ | ✅ Pass |
-| Unit tests passing | 940/949 | 95%+ | ✅ 99% |
+| Unit test files | 58 (main suite) + 7 (otel-mcp-server) | 40+ | ✅ Pass |
+| Unit tests passing | 1,100+ (1,088 main suite + 99 otel-mcp-server) | 95%+ | ✅ Pass |
 | E2E test suites | 3 | 3+ | ✅ Pass |
 | Integration tests | 20+ | 15+ | ✅ Pass |
 
@@ -86,7 +86,7 @@
 ### 2.3 Known Test Issues ⚠️
 | Issue | Impact | Notes |
 |-------|--------|-------|
-| 9 failing tests | Low | Pre-existing price feed mock issues |
+| 14 skipped tests | Low | Intentionally skipped (environment-dependent); 0 failing as of 2026-07-05 |
 | TODO comments in tests | Low | Tech debt markers for future refactoring |
 
 ---
@@ -119,7 +119,7 @@
 ### 3.4 Infrastructure Gaps ⚠️
 | Issue | Severity | Recommendation |
 |-------|----------|----------------|
-| Backup strategy documented | ✅ Done | `docs/BACKUP_RESTORE.md` |
+| Backup strategy documented | ✅ Done | `docs/operations/03_BACKUP_RESTORE.md` |
 | Disaster recovery plan | ✅ Done | Included in BACKUP_RESTORE.md |
 | Horizontal scaling configured | ✅ Done | HPA templates + values.yaml ready |
 
@@ -153,7 +153,7 @@
 ### 4.4 Alerting ✅
 | Check | Status | Notes |
 |-------|--------|-------|
-| Alert rules defined | ✅ Pass | 25+ rules in `config/alerting-rules.yml` |
+| Alert rules defined | ✅ Pass | 48 rules in 11 groups in `config/alerting-rules.yml` |
 | Incident management | ✅ Pass | GoAlert + Alertmanager configured |
 | Mobile notifications | ✅ Pass | ntfy.sh webhook integration |
 
@@ -246,11 +246,11 @@ No production runtime vulnerabilities.
 
 ### Blockers (Must Fix) ✅ ALL RESOLVED
 - [x] ~~Remediate 23 high-severity npm vulnerabilities~~ → Fixed via npm overrides
-- [x] ~~Document backup and disaster recovery procedures~~ → `docs/BACKUP_RESTORE.md`
+- [x] ~~Document backup and disaster recovery procedures~~ → `docs/operations/03_BACKUP_RESTORE.md`
 - [x] ~~Configure TLS termination~~ → Use Kong Gateway or ingress controller
 
 ### High Priority (Should Fix) ✅ ALL RESOLVED
-- [x] ~~Create operational runbook~~ → `docs/RUNBOOK.md`
+- [x] ~~Create operational runbook~~ → `docs/operations/04_RUNBOOK.md`
 - [x] ~~Define alerting rules in Prometheus~~ → `config/alerting-rules.yml`
 - [x] ~~Configure incident management~~ → GoAlert + ntfy
 - [x] ~~Test horizontal scaling (2+ replicas)~~ → HPA templates ready

--- a/docs/operations/GOALERT_SETUP.md
+++ b/docs/operations/GOALERT_SETUP.md
@@ -10,9 +10,9 @@ Quick-start guide for configuring incident management and phone notifications.
 
 1. **Open GoAlert UI** → First-time setup wizard appears
 2. **Create Admin Account**
-   - Username: `carlos` (or your preference)
+   - Username: `<your-name>` (or your preference)
    - Password: (choose a secure password)
-   - Email: `carlos@krystaline.io`
+   - Email: `<you@example.com>`
 
 ## 🛠️ Configuration Steps
 
@@ -90,7 +90,7 @@ Alerts from Prometheus rules will automatically route through Alertmanager → G
 ```
 Prometheus → Alertmanager → GoAlert → Phone/SMS/Email
      ↓              ↓
-  (rules)    (carlos@krystaline.io)
+  (rules)    (<you@example.com>)
 ```
 
 ## 🚨 Alert Routing (Current Config)

--- a/docs/operations/deployment-runbook.md
+++ b/docs/operations/deployment-runbook.md
@@ -34,12 +34,11 @@ Scope: deploy, verify, and roll back Krystaline via Docker Compose (demo/dev) or
 3. Start app services (host-run per repo guidance):
    ```bash
    npm install
-   npm run dev:server      # backend
-   npm run dev:payments    # payment-processor if applicable
-   npm run dev:client      # frontend
+   npm run dev             # full dev stack (API + payment-processor + frontend)
+   # or: npm run dev:server   # API server alone
    ```
 4. Health checks:
-   - API: curl http://localhost:3000/health and /ready
+   - API: curl http://localhost:5000/health and /ready
    - Kong: curl http://localhost:8001/status
    - RabbitMQ UI: http://localhost:15672 (prom plugin on 15692)
    - Jaeger UI: http://localhost:16686
@@ -111,12 +110,12 @@ Scope: deploy, verify, and roll back Krystaline via Docker Compose (demo/dev) or
 ## 5) Observability smoke scripts (optional/manual)
 - Simple request + trace check:
   ```bash
-  curl -X GET http://localhost:3000/api/health
+  curl -X GET http://localhost:5000/api/health
   # then confirm trace in Jaeger UI (or via API if available)
   ```
 - Metrics probe:
   ```bash
-  curl -s http://localhost:3000/metrics | grep http_requests_total | head
+  curl -s http://localhost:5000/metrics | grep http_requests_total | head
   ```
 - Collector health:
   ```bash

--- a/docs/product/01_ROADMAP.md
+++ b/docs/product/01_ROADMAP.md
@@ -8,13 +8,13 @@
 
 ## Executive Summary
 
-Krystaline is a cryptocurrency trading platform differentiated by **Proof of Observability™** — full transaction transparency via OpenTelemetry distributed tracing. The platform has reached **investor demo readiness** with comprehensive security, 940+ passing tests, and advanced observability including LLM-powered anomaly analysis.
+Krystaline is a cryptocurrency trading platform differentiated by **Proof of Observability** — full transaction transparency via OpenTelemetry distributed tracing. The platform has reached **investor demo readiness** with comprehensive security, 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server), and advanced observability including LLM-powered anomaly analysis.
 
 ### Unique Value Proposition
 
-> "See exactly how your trade was processed — no other exchange does this."
+> "See exactly how your trade was processed — we're not aware of another exchange that shows you this."
 
-Every transaction generates a **17-span distributed trace** visible to users, proving system integrity and building unprecedented trust in a typically opaque industry.
+Every transaction generates a **distributed trace — typically 17+ spans on the full RabbitMQ trade path** — visible to users, proving system integrity and building trust in a typically opaque industry.
 
 ---
 
@@ -25,7 +25,7 @@ Every transaction generates a **17-span distributed trace** visible to users, pr
 | Area | Status | Details |
 |------|--------|---------|
 | **Security** | ✅ Done | Rate limiting (3-tier), Helmet, bcrypt(12), JWT refresh, 2FA TOTP |
-| **Testing** | ✅ Done | 940+ tests, 43 files, E2E Playwright tests |
+| **Testing** | ✅ Done | 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server), E2E Playwright tests |
 | **Health Endpoints** | ✅ Done | `/health` (liveness), `/ready` (readiness) |
 | **Graceful Shutdown** | ✅ Done | SIGTERM/SIGINT handlers |
 | **Error Handling** | ✅ Done | Global handler, AppError hierarchy |
@@ -42,9 +42,9 @@ Every transaction generates a **17-span distributed trace** visible to users, pr
 | **Baseline Persistence** | ✅ Done | PostgreSQL-backed span baselines |
 
 ### 📊 Metrics
-- **Tests:** 940+ passing
+- **Tests:** 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server)
 - **E2E Tests:** 3 suites passing
-- **Docker Services:** 14 containers
+- **Docker Services:** 22 services in docker-compose.yml
 - **API Endpoints:** 40+ routes
 - **Frontend Pages:** 9 complete
 
@@ -74,10 +74,10 @@ Every transaction generates a **17-span distributed trace** visible to users, pr
 #### What to Demonstrate
 1. **User Journey** (5 min) - Registration, email verification, JWT login
 2. **Trading Flow** (3 min) - Real Binance prices, order execution
-3. **Transparency Magic** (5 min) - 17-span Jaeger traces, verified integrity
+3. **Transparency Magic** (5 min) - Jaeger traces (typically 17+ spans), verified integrity
 4. **Anomaly Detection** (3 min) - LLM-powered root cause analysis
 
-See [DEMO-WALKTHROUGH.md](DEMO-WALKTHROUGH.md) for step-by-step script.
+See [03_DEMO_WALKTHROUGH.md](03_DEMO_WALKTHROUGH.md) for step-by-step script.
 
 ---
 
@@ -149,10 +149,10 @@ npm run dev
 ## Key Talking Points
 
 ### For Seed Investors
-- "Every trade generates a verifiable 17-span trace"
+- "Every trade generates a verifiable trace (typically 17+ spans)"
 - "AI-powered anomaly detection catches issues before users notice"
 - "Real Binance prices, not fake demo data"
-- "940+ tests ensure reliability"
+- "1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server) ensure reliability"
 
 ### For Series A
 - "Production security from day one: rate limiting, bcrypt, JWT, 2FA"

--- a/docs/product/02_USER_JOURNEY.md
+++ b/docs/product/02_USER_JOURNEY.md
@@ -7,7 +7,7 @@
 
 ## Executive Summary
 
-This document defines the user journey for Krystaline, highlighting our core value proposition: **Proof of Observability™**. All major flows have been implemented and are investor-demo ready.
+This document defines the user journey for Krystaline, highlighting our core value proposition: **Proof of Observability**. All major flows have been implemented and are investor-demo ready.
 
 ---
 
@@ -25,12 +25,12 @@ This document defines the user journey for Krystaline, highlighting our core val
 | Real Price Feed | ✅ Complete | Binance WebSocket, real-time BTC/ETH |
 | Transparency API | ✅ Complete | Public trades with verified traces |
 | Monitoring | ✅ Complete | Anomaly detection, WebSocket streaming |
-| OpenTelemetry | ✅ Complete | Full 17-span distributed tracing |
+| OpenTelemetry | ✅ Complete | Distributed tracing, typically 17+ spans on the full RabbitMQ trade path (observed in demo traces) |
 
 ### Frontend Pages ✅
 | Route | Component | Status |
 |-------|-----------|--------|
-| `/` | Landing Page | ✅ Proof of Observability™ story |
+| `/` | Landing Page | ✅ Proof of Observability story |
 | `/register` | Registration | ✅ Clean signup flow |
 | `/verify-email/:token` | Email Verification | ✅ 6-digit code entry |
 | `/login` | Login | ✅ Professional login |
@@ -47,7 +47,7 @@ This document defines the user journey for Krystaline, highlighting our core val
 ### Phase 1: Discovery (Public)
 
 ```
-Landing Page (/) → "Proof of Observability™" → Sign Up CTA
+Landing Page (/) → "Proof of Observability" → Sign Up CTA
 ```
 
 **What Users See:**
@@ -183,8 +183,8 @@ Register → Verify Email → Login → Dashboard
 ## Demo Script Reference
 
 For step-by-step investor demonstration, see:
-- [DEMO-WALKTHROUGH.md](DEMO-WALKTHROUGH.md) - Full demo script
-- [ROADMAP.md](ROADMAP.md) - Feature timeline
+- [03_DEMO_WALKTHROUGH.md](03_DEMO_WALKTHROUGH.md) - Full demo script
+- [01_ROADMAP.md](01_ROADMAP.md) - Feature timeline
 
 ---
 

--- a/docs/product/03_DEMO_WALKTHROUGH.md
+++ b/docs/product/03_DEMO_WALKTHROUGH.md
@@ -1,6 +1,6 @@
 # Krystaline Investor Demo Walkthrough
 
-> **Purpose:** Step-by-step guide to demonstrate "Proof of Observability™"  
+> **Purpose:** Step-by-step guide to demonstrate "Proof of Observability"  
 > **Duration:** 12-15 minutes  
 > **Updated:** 2026-03-01  
 > **Environment:** Kubernetes (Helm) at `www.krystaline.io`
@@ -39,7 +39,7 @@ curl -X POST https://www.krystaline.io/api/v1/monitor/recalculate
 **Navigate to:** `https://www.krystaline.io` (Landing Page)
 
 **What You'll See:**
-- "Proof of Observability™" headline
+- "Proof of Observability" headline
 - Live system status badge
 - Performance metrics (P50, P95, P99)
 - 100% Transaction Coverage indicator
@@ -132,7 +132,7 @@ Client → Kong Gateway → Express API → RabbitMQ → Order Matcher → Postg
 Opens Jaeger directly to this trade's trace
 
 **Option B: Open Jaeger Manually**
-- Navigate to: `https://www.krystaline.io/jaeger/` (requires nginx basic auth)\r
+- Navigate to: `https://www.krystaline.io/jaeger/` (requires nginx basic auth)
 - Service: `krystalinex` or `kong`
 - Click "Find Traces"
 - Select most recent trace
@@ -140,7 +140,7 @@ Opens Jaeger directly to this trade's trace
 **What to Show in Jaeger:**
 
 1. **Trace Overview**
-   - See 10-17 spans in a waterfall
+   - See the trace waterfall — typically 17+ spans on the full RabbitMQ trade path (observed in demo traces)
    - Total duration in milliseconds
 
 2. **Span Breakdown**
@@ -225,7 +225,7 @@ Opens Jaeger directly to this trade's trace
 > "Yes. Prices come from Binance WebSocket. Trades go through a real order matching engine. PostgreSQL stores everything."
 
 ### "How many spans per transaction?"
-> "Typically 15-20 spans covering: API Gateway, authentication, validation, database reads, message queue, order matching, balance updates."
+> "Typically 17+ spans on the full RabbitMQ trade path (observed in demo traces), covering: API Gateway, authentication, validation, database reads, message queue, order matching, balance updates."
 
 ### "What if there's an anomaly?"
 > "Show `/monitor`. Our system detects slowdowns automatically, calculates severity, and can use LLMs to diagnose root causes."

--- a/docs/product/04_INVESTOR_DEMO_SCRIPT.md
+++ b/docs/product/04_INVESTOR_DEMO_SCRIPT.md
@@ -12,7 +12,7 @@
 
 ```
 ACT 1  The Problem           (3 min)   Why exchanges fail at trust
-ACT 2  The Promise           (2 min)   Proof of Observability™ landing page
+ACT 2  The Promise           (2 min)   Proof of Observability landing page
 ACT 3  Real Platform         (3 min)   Register → Login → Trade (credibility)
 ACT 4  The Complete Picture  (5 min)   Tracing + Exemplars + Logs = audit trail
 ACT 5  Automated Detection   (4 min)   Anomaly detector catches what humans miss
@@ -97,7 +97,7 @@ curl -s https://www.krystaline.io/api/v1/monitor/model | jq '.model'
 
 ### What You'll See
 
-- **"Proof of Observability™"** headline
+- **"Proof of Observability"** headline
 - Live system status badge (Operational / Degraded)
 - Performance metrics (P50, P95, P99 response times)
 - "100% Transaction Coverage" indicator
@@ -108,7 +108,7 @@ curl -s https://www.krystaline.io/api/v1/monitor/model | jq '.model'
 >
 > "See these numbers? P50: 12ms, P95: 45ms, P99: 243ms. Those aren't benchmarks from a slide deck. They're calculated in real-time from production OpenTelemetry instrumentation — the same standard used by Google, AWS, and every major cloud provider."
 >
-> "And this: **100% Transaction Coverage**. Every single trade that goes through our system generates a complete distributed trace — typically 17 spans — that you can inspect yourself. Not a sample. Not a summary. Every one."
+> "And this: **100% Transaction Coverage**. Every single trade that goes through our system generates a complete distributed trace — typically 17+ spans on the full RabbitMQ trade path (observed in demo traces) — that you can inspect yourself. Not a sample. Not a summary. Every one."
 >
 > "Let me prove it."
 
@@ -162,7 +162,7 @@ curl -s https://www.krystaline.io/api/v1/monitor/model | jq '.model'
 
 ### What You'll See
 
-- A waterfall diagram showing 10–17 spans
+- A waterfall diagram — typically 17+ spans on the full RabbitMQ trade path (observed in demo traces)
 - Each span represents one operation in one service
 - Total trace duration in milliseconds
 
@@ -286,7 +286,7 @@ curl -s https://www.krystaline.io/api/v1/monitor/model | jq '.model'
 
 > *[When analysis completes, read the summary]*
 
-> "See this? It identified the likely cause, gave us three recommendations ranked by priority, and rated its own confidence. This is a senior SRE's analysis — in 2 seconds instead of 30 minutes."
+> "See this? It identified the likely cause, gave us three recommendations ranked by priority, and rated its own confidence. This is a structured first-pass triage in ~2 seconds that on-call then verifies — instead of 30 minutes of manual investigation."
 
 ### 6A: The Training Loop
 
@@ -353,7 +353,7 @@ GET /api/public/zk/proof/:tradeId  → Returns proof + public signals + verifica
 GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourself)
 ```
 
-> "We also generate a **solvency proof** every 60 seconds. It proves our total reserves are greater than or equal to our liabilities — without revealing any individual user's balance. That's the 'zero-knowledge' part: we prove the statement is true without revealing the underlying data."
+> "We also generate a **solvency proof** every 60 seconds — a Groth16 proof, verified server-side, that our total reserves are greater than or equal to our liabilities, without revealing any individual user's balance. The public endpoint publishes the Poseidon commitment; the per-trade integrity proofs are the ones anyone can verify independently. That's the 'zero-knowledge' part: we prove the statement is true without revealing the underlying data."
 
 ### 7D: The ZK Stats
 
@@ -361,7 +361,7 @@ GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourse
 
 > "Total proofs generated, average proving time — about 200 milliseconds per proof — verification success rate near 100%. And the solvency proof age tells you how recent the latest proof is. It's never more than 60 seconds old."
 >
-> "Traditional exchanges prove solvency once a year with an accounting firm. We prove it every minute with mathematics."
+> "Traditional exchanges prove solvency once a year with an accounting firm. We run that check every minute with mathematics — the proof is verified server-side, and the Poseidon commitment is published publicly."
 
 ---
 
@@ -381,15 +381,15 @@ GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourse
 >
 > "**Third: AI-powered diagnosis** — a locally-hosted LLM that's being fine-tuned specifically on our infrastructure patterns. It gets smarter every week. The training pipeline is in our repo — reproducible, auditable AI ops."
 >
-> "**Fourth: Cryptographic verification** — Groth16 zero-knowledge proofs on every trade, solvency proofs every 60 seconds, all publicly verifiable without trusting our infrastructure."
+> "**Fourth: Cryptographic verification** — Groth16 zero-knowledge proofs on every trade, publicly verifiable without trusting our infrastructure, plus a solvency proof every 60 seconds — verified server-side, with the Poseidon commitment published publicly."
 
 ### The Competitive Position
 
-> "Coinbase has brand. Kraken has liquidity. But neither of them can show you a distributed trace of your trade. Neither generates a cryptographic proof of fair execution. Neither has an AI that explains anomalies in real-time."
+> "Coinbase has brand. Kraken has liquidity. But we're not aware of another exchange that publishes per-trade traces — major exchange status pages show aggregate uptime only. Neither generates a cryptographic proof of fair execution. Neither has an AI that explains anomalies in real-time."
 >
 > "Our moat is architectural. It's not a feature you bolt on — it's how the system is built from the ground up. A competitor would need 12 to 18 months to replicate this, and by then we'll have 18 months of fine-tuning data making our AI better."
 >
-> "We have 940 automated tests passing, a production Kubernetes deployment, real Binance prices, and every piece of infrastructure as code in our repository. This is production-grade engineering, not a demo."
+> "We have 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server), a production Kubernetes deployment, real Binance prices, and every piece of infrastructure as code in our repository. This is production-grade engineering, not a demo."
 
 ### The Ask
 
@@ -405,7 +405,7 @@ GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourse
 
 ### "How many spans per transaction?"
 
-> "Typically 15–20 spans covering: API Gateway (Kong), authentication, input validation, database reads/writes, message queue publish/consume, order matching, wallet updates, and ZK proof generation. Every span captures structured attributes — not just timing, but business context like order pair, price, and user ID."
+> "Typically 17+ spans on the full RabbitMQ trade path (observed in demo traces), covering: API Gateway (Kong), authentication, input validation, database reads/writes, message queue publish/consume, order matching, wallet updates, and ZK proof generation. Every span captures structured attributes — not just timing, but business context like order pair, price, and user ID."
 
 ### "What happens if the LLM gives a wrong diagnosis?"
 
@@ -429,7 +429,7 @@ GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourse
 
 ### "What's the team size?"
 
-> *[Adjust to your actual team]* "We're a small team that punches above our weight because of our engineering philosophy: everything is tested (940+ tests), everything is instrumented (17 spans per trade), and everything is automated (anomaly detection, AI diagnosis, ZK proof generation). Our observability infrastructure is itself observable."
+> *[Adjust to your actual team]* "We're a small team that punches above our weight because of our engineering philosophy: everything is tested (1,100+ passing automated tests: 1,088 in the main suite + 99 in otel-mcp-server), everything is instrumented (17 spans per trade), and everything is automated (anomaly detection, AI diagnosis, ZK proof generation). Our observability infrastructure is itself observable."
 
 ---
 
@@ -479,7 +479,7 @@ GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourse
 | **ZK Proofs** | Groth16 (snarkjs) | ~200ms proving, BN128 curve |
 | **Alerting** | Alertmanager → GoAlert | Multi-window burn rate (14.4x/6x/3x/1x) |
 | **Deployment** | Kubernetes (3 nodes) | Helm charts, Cloudflare tunnel |
-| **Tests** | Vitest + Playwright | 940+ tests, API smoke + E2E |
+| **Tests** | Vitest + Playwright | 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server), API smoke + E2E |
 | **Security** | bcrypt(12), JWT, 2FA/TOTP | 3-tier rate limiting, SIEM webhook |
 
 ---
@@ -502,11 +502,11 @@ GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourse
 
 ---
 
-## Appendix: The Five Pillars of Proof of Observability™
+## Appendix: The Five Pillars of Proof of Observability
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                   PROOF OF OBSERVABILITY™                       │
+│                   PROOF OF OBSERVABILITY                        │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
 │  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌──────┐   │
@@ -533,7 +533,7 @@ GET /api/public/zk/verify/:tradeId → Server-side verification (or do it yourse
 
 **Pillar 3 — AI Diagnosis:** Locally-hosted Llama 3.2 (1B parameters) receives rich context — span attributes, system metrics, full trace — and streams structured root cause analysis in real-time via WebSocket. LoRA fine-tuning on production feedback creates a continuously improving model.
 
-**Pillar 4 — ZK Proofs:** Groth16 zk-SNARKs commit every trade to its execution details (price, quantity, user, timestamp, trace ID) via Poseidon hashing. Solvency proofs generated every 60 seconds. All publicly verifiable with the open-source `snarkjs` library.
+**Pillar 4 — ZK Proofs:** Groth16 zk-SNARKs commit every trade to its execution details (price, quantity, user, timestamp, trace ID) via Poseidon hashing. Trade-integrity proofs are publicly verifiable with the open-source `snarkjs` library; solvency proofs are generated every 60 seconds and verified server-side, with the Poseidon commitment published publicly.
 
 **Pillar 5 — SLO Framework:** Google SRE multi-window burn rate alerting on 99.9% availability and P95 < 500ms latency targets. Error budgets track remaining tolerance. Burn rates trigger alerts before users notice degradation.
 

--- a/docs/xgenDocs/diagrams/README.md
+++ b/docs/xgenDocs/diagrams/README.md
@@ -8,8 +8,8 @@ This folder contains mermaid source files (`*.mmd`) used to render diagrams embe
 
 2. Render the diagrams to SVG in `docs/images`:
 
-   npx mmdc -i docs/diagrams/trace-hierarchy.mmd -o docs/images/trace-hierarchy.svg -b transparent
-   npx mmdc -i docs/diagrams/baseline-calculation.mmd -o docs/images/baseline-calculation.svg -b transparent
+   npx mmdc -i docs/xgenDocs/diagrams/trace-hierarchy.mmd -o docs/images/trace-hierarchy.svg -b transparent
+   npx mmdc -i docs/xgenDocs/diagrams/baseline-calculation.mmd -o docs/images/baseline-calculation.svg -b transparent
 
 3. (Optional) Generate all diagrams with the convenience npm script:
    - `npm run render:diagrams` (requires Node >= 14)

--- a/lora-anomaly-analyzer/README.md
+++ b/lora-anomaly-analyzer/README.md
@@ -5,14 +5,11 @@ base_model: meta-llama/Llama-3.2-1B-Instruct
 tags:
 - generated_from_trainer
 datasets:
-- /data/data/training-data-combined.jsonl
+- ../training-data.jsonl
 model-index:
 - name: data/lora-anomaly-analyzer
   results: []
 ---
-
-<!-- This model card has been generated automatically according to the information the Trainer had access to. You
-should probably proofread and complete it, then remove this comment. -->
 
 [<img src="https://raw.githubusercontent.com/axolotl-ai-cloud/axolotl/main/image/axolotl-badge-web.png" alt="Built with Axolotl" width="200" height="32"/>](https://github.com/axolotl-ai-cloud/axolotl)
 <details><summary>See axolotl config</summary>
@@ -102,19 +99,19 @@ seed: 42
 
 # data/lora-anomaly-analyzer
 
-This model is a fine-tuned version of [meta-llama/Llama-3.2-1B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct) on the /data/data/training-data-combined.jsonl dataset.
+This model is a fine-tuned version of [meta-llama/Llama-3.2-1B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct) on the repo's anomaly training data (`../training-data.jsonl`).
 
 ## Model description
 
-More information needed
+A LoRA adapter (r=16, alpha=32) for meta-llama/Llama-3.2-1B-Instruct, fine-tuned to analyze crypto exchange anomaly events — see [../docs/observability/04_FINE_TUNING.md](../docs/observability/04_FINE_TUNING.md) for the full fine-tuning workflow.
 
 ## Intended uses & limitations
 
-More information needed
+Intended for local anomaly root-cause analysis in the Krystaline monitoring stack; as a 1B-parameter fine-tune, its output is an assistive summary, not an authoritative diagnosis.
 
 ## Training and evaluation data
 
-More information needed
+Trained on the repo's anomaly training data (`../training-data.jsonl`), with 5% held out for evaluation.
 
 ## Training procedure
 

--- a/otel-mcp-server/README.md
+++ b/otel-mcp-server/README.md
@@ -513,10 +513,10 @@ npx vitest run tests/auth.test.ts
 
 ## Appendix: Live Cluster Analysis
 
-The following analysis was generated entirely by an AI agent (GitHub Copilot CLI) using this MCP server to query a production Krystaline cluster — 27 tool calls across 6 skills, zero manual commands. This is what "Proof of Observability" looks like in practice.
+The following analysis was generated entirely by an AI agent (GitHub Copilot CLI) using this MCP server to query a 3-node bare-metal K8s lab cluster running the full Krystaline exchange stack — 27 tool calls across 6 skills, zero manual commands. This is what "Proof of Observability" looks like in practice.
 
 > **Cluster**: Krystaline crypto exchange · 3-node K8s (1 control-plane, 2 workers) · Helm-managed
-> **MCP Server**: v1.2.1 · 6/7 skills active (Elasticsearch disabled) · session-based HTTP transport  
+> **MCP Server**: v1.2.0 · 6/7 skills active (Elasticsearch disabled) · session-based HTTP transport  
 > **Date**: 2026-03-24T19:30 UTC
 
 ---

--- a/server/mcp/index.ts
+++ b/server/mcp/index.ts
@@ -591,7 +591,7 @@ server.resource(
 - Price Freshness: ≤ 5s staleness
 
 ## Anomaly Detection
-- Trace-based: Z-score > 6.6σ on span durations (Welford's algorithm, 168 hourly buckets)
+- Trace-based: Z-score > 3.0σ (SEV5) up to 8.0σ (SEV1) on span durations (Welford's algorithm, 168 hourly buckets)
 - Amount-based: Z-score > 3.0σ on transaction amounts (whale detection)
 - Bayesian: Hierarchical probabilistic model (PyMC) for latency/error anomaly with root cause ranking
 - LLM RCA: Ollama-powered root cause analysis with Prometheus metric correlation


### PR DESCRIPTION
## Summary

First PR from the documentation review: pure correction pass so that every checkable claim in the public docs matches the code. For a project whose thesis is *"verifiable before it asks anyone to trust it,"* these were claims a reader could falsify in minutes.

### Broken references
- Repointed all links to the removed `docs/GENAI_OBSERVABILITY_SOLUTION.md` (README quick links + doc map, public catalog, blog references, archive index)
- Fixed the README dashboard-pack image path (file lives under `docs/blog/assets/`)
- Replaced the whitepaper's 8 screenshots pointing into the empty `docs/images/` with TODO comments preserving captions
- Replaced 15 `file:///c:/Users/...` links (broken for every reader, leaked a local username and the pre-rename repo name) with repo-relative links; `server/instrumentation.ts` references now point at `server/otel.ts`
- Fixed wrong-depth relative links in the technical assessment (13), product docs, runbook, and xgenDocs render commands

### Numbers now match the code (all verified against source or measured on 2026-07-05)
| Claim | Was | Now |
|---|---|---|
| Severity ladder | 1.3–3.3σ, 500 obs min | 3.0–8.0σ, `MIN_SAMPLES=10` (`server/monitor/anomaly-detector.ts`) |
| Whale thresholds | 1.3–20.6σ | 3.0–7.0σ (`server/monitor/types.ts`) |
| LoRA adapter | r=32 / α=64 | r=16 / α=32 (`axolotl-config.yaml`) |
| Alert rules | 34/9, 25+, 85/18 (three variants) | 48 rules / 11 groups (`config/alerting-rules.yml`) |
| Rate limits | 100/20/5 and 300/60/30 variants | 300/60/15 per minute (`server/middleware/security.ts`) |
| Tests | "940+", 931, 712/714, "9 failing" | 1,100+ passing (1,088 main + 99 otel-mcp-server), 14 skipped, 0 failing — measured |
| Compose services | 18 / 14 | 22 (`docker-compose.yml`) |
| Unified dashboard | 52 panels / 68 queries | 73 panels / 79 targets (undersold) |
| Trade spans | six variants (8–15+, 10–17, 15–20, 17…) | canonical "typically 17+ spans on the full RabbitMQ trade path (observed)" |

### Honesty-posture cleanups
- Removed stray ™ marks, "institutional-grade", "near-zero MTTD", and the uncited ~10×/~100× MTTR comparison
- Corrected the exec-summary claim that proofs cover "uptime" (they cover trade integrity + solvency commitment)
- Qualified all "proves reserves ≥ liabilities" solvency language (commitment published; Groth16 proof verified server-side) — consistent with #35
- Replaced the fictional "KYC completions (84%)" funnel in MCP Top-20 Q18 with the real registration → email verification → first trade funnel, and marked example responses as illustrative transcripts
- Softened unverifiable superlatives in the investor script and roadmap to evidence-anchored comparatives

### Leak scrubbing
- `bizait-nas:5000` registry host, personal name/email in GoAlert setup, local Windows path in backup docs, working default RabbitMQ credentials

### Misc
- CONTRIBUTING now says branch from `develop`; deployment runbook uses real npm scripts and port 5000; lora-anomaly-analyzer README no longer contains auto-generated "you should probably proofread this" placeholder text; `server/mcp/index.ts` runbook resource states the real severity ladder (was "6.6σ")

## Verification
- `npm test` — 1,088 passed, 14 skipped
- `otel-mcp-server npm test` — 99 passed
- `npm run check` — clean
- `npm run ci:check-docs` — no confidential markers
- Custom link checker over all active docs — every relative link/image resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)