### PR TITLE
Rewrite README front door and architecture doc around verified evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Krystaline Observability Lab
 
-Status: Public  
-Audience: contributors, observability experts, SRE leaders, service managers, technical reviewers  
-Classification: Public-safe overview
-
 **Open-source crypto and DeFi observability lab for OpenTelemetry, AI SRE, proof systems, and service-manager operations.**
 
 Krystaline Observability Lab is the public expression of the Krystaline thesis:
@@ -14,20 +10,54 @@ The lab uses realistic exchange and DeFi workflows as the stress test. Orders,
 wallet updates, market-data paths, proof generation, queues, alerts, and service
 health all become observable product signals. A trade-like flow can be captured
 in a distributed trace, evaluated by statistical anomaly detection, summarized
-by an AI SRE layer, correlated by Bayesian inference, and connected to
-zero-knowledge proof concepts.
+by an AI SRE layer, correlated by Bayesian inference, and cryptographically
+bound to a zero-knowledge proof.
 
 Krystaline Core is the private research and product-acceleration platform. This
 repository shows the public architecture, operating model, demo experience, and
 open implementation pieces without exposing private Core internals.
 
-Some runtime identifiers still use legacy names such as `krystalinex`, `kx-*`,
-or `kx_*` while public-facing prose moves to **Krystaline** and **Krystaline
-Observability Lab**. See [Brand Positioning](docs/BRAND_POSITIONING.md) for the
-naming policy.
-
 **Live lab:** [krystaline.io](https://www.krystaline.io)  
 **License:** [Apache-2.0](LICENSE)
+
+## Proof, Not Promises
+
+Every claim below is one click from its evidence in this repository.
+
+| Verified capability | Evidence |
+|---|---|
+| One W3C trace from browser click to settlement — typically 17+ spans on the full RabbitMQ trade path (observed in demo traces), stitched across the async hop by dual context headers (`traceparent` + `x-parent-traceparent`) | [`server/services/rabbitmq-client.ts`](server/services/rabbitmq-client.ts), [`payment-processor/index.ts`](payment-processor/index.ts) |
+| A Groth16 proof fires (non-blocking) for every filled trade, committing the OTel 128-bit `traceId` into a Poseidon(5) hash so swapping the trace invalidates the proof — a 977-wire circuit with committed proving keys; a 2026-07-05 benchmark run against those artifacts measured warm proving at 129–152 ms and verification at 12–20 ms (724-byte proof) | [`server/circuits/trade_integrity.circom`](server/circuits/trade_integrity.circom), [`server/circuits/build/`](server/circuits/build/), [`server/services/zk-proof-service.ts`](server/services/zk-proof-service.ts) |
+| Adaptive statistical baselines: Welford's online algorithm for trade-amount whale detection, plus 168 time buckets (7 days × 24 hours) per span key with thresholds learned from empirical 80–99.9th percentiles | [`server/monitor/amount-profiler.ts`](server/monitor/amount-profiler.ts), [`server/monitor/baseline-calculator.ts`](server/monitor/baseline-calculator.ts) |
+| Local-first LLM RCA whose own pipeline is metered: 5 `kx_llm_*` Prometheus metric families, pre-initialized to zero, with a bounded queue (100) and labeled load-shedding | [`server/monitor/stream-analyzer.ts`](server/monitor/stream-analyzer.ts) |
+| AI agents get read-only MCP access to traces, metrics, logs, and alerts — including cryptographic verification of trade proofs via a real `snarkjs.groth16.verify()` | [`server/mcp/index.ts`](server/mcp/index.ts) (28 tools), [`otel-mcp-server/`](otel-mcp-server/) (32 tools) |
+| 1,100+ passing automated tests (1,088 main suite + 99 in otel-mcp-server); a confidential-marker scanner ships as the repo's `precommit` script to guard the public/private doc boundary | [`tests/`](tests/), [`otel-mcp-server/tests/`](otel-mcp-server/tests/), [`scripts/check-confidential-docs.cjs`](scripts/check-confidential-docs.cjs) |
+
+## See It in Five Minutes
+
+```bash
+git clone https://github.com/MoebiusX/Krystaline.git
+cd Krystaline
+npm install --legacy-peer-deps
+npm run dev   # Docker Desktop must be running; this starts 21 compose services + API + matcher + Vite
+```
+
+1. Open <http://localhost:5173> and register. Email verification arrives in
+   MailDev at <http://localhost:1080>.
+2. Buy 0.001 BTC. The success toast and the trade-verified modal both deep-link
+   to your trade's trace; every row on the activity page links its `traceId`
+   to Jaeger.
+3. Open the trace in Jaeger at <http://localhost:16686> — typically 17+ spans
+   across 4 services on the full RabbitMQ trade path, starting with the
+   `order.submit.client` span from your own browser.
+4. Verify the trade's zero-knowledge proof:
+   `GET http://localhost:5000/api/public/zk/verify/:tradeId` runs a real
+   Groth16 verification server-side and returns the mathematical verdict.
+
+Other local URLs: Grafana <http://localhost:3000> (admin/admin), Prometheus
+:9090, Alertmanager :9093, RabbitMQ :15672, Kong admin :8001, GoAlert :8081.
+The Bayesian service is the one container `npm run dev` does not start — run
+`docker compose up bayesian-service` separately.
 
 ## Quick Links
 
@@ -76,77 +106,72 @@ For observability experts, Krystaline is an opinionated reference architecture
 for AI-assisted operations that keeps traceability, auditability, deterministic
 paging, and human authority at the center.
 
-## One-Page Visual
+## Trade Lifecycle
+
+One trade, one trace, one proof — this is the actual runtime path, not an
+idealized one:
 
 ```mermaid
 flowchart TB
-    A["Trade, transfer, proof,<br/>or service event"]
-    B["OpenTelemetry trace"]
-    C["Prometheus / VictoriaMetrics<br/>metrics"]
-    D["Structured logs"]
-    E["Anomaly and baseline<br/>engine"]
-    F["SLO and alert state"]
-    G["AI SRE context packet"]
-    H["Read-only MCP<br/>telemetry tools"]
-    I["RCA hypothesis, evidence,<br/>and next action"]
-    J["Operator war room"]
-    K["Service manager briefing"]
-    L["Post-incident review"]
-    M["Public transparency<br/>and proof surface"]
+    BR["Browser (kx-wallet)<br/>order.submit.client span"] --> KG["Kong gateway<br/>OTel plugin"]
+    KG --> API["Exchange API (kx-exchange)<br/>POST /api/v1/orders"]
+    API -->|"traceparent +<br/>x-parent-traceparent"| MQ["RabbitMQ"]
+    MQ --> MATCH["Order matcher<br/>(kx-matcher)"]
+    MATCH -->|"reply echoes original<br/>POST trace context"| API
+    API --> SETTLE["Wallet settlement"]
+    SETTLE -.->|"non-blocking"| ZK["Groth16 trade proof<br/>traceId committed in Poseidon hash"]
 
-    A --> B
-    A --> C
-    A --> D
-    B --> E
-    C --> E
-    D --> E
-    E --> F
-    F --> G
-    B --> G
-    C --> G
-    D --> G
-    H --> G
-    G --> I
-    I --> J
-    I --> K
-    I --> L
-    B --> M
+    API --> COLL["OTel Collector<br/>tail sampling: keep all errors,<br/>&gt;500ms, money-path traces"]
+    COLL --> JAEGER["Jaeger"]
+    API --> PROM["Prometheus"]
+    API --> LOKI["Loki"]
+
+    JAEGER --> DETECT["Anomaly detection<br/>adaptive baselines,<br/>severity ladder 3.0σ–8.0σ"]
+    DETECT --> LLM["LLM RCA<br/>(local Ollama)"]
+    DETECT --> BAYES["Bayesian correlation<br/>(PyMC service)"]
+    DETECT --> AM["Alertmanager → GoAlert<br/>deterministic paging"]
+
+    ZK --> PUB["Public proof APIs<br/>/api/public/zk/*"]
+    JAEGER --> MCP["Read-only MCP tools<br/>incl. zk_proof_verify"]
+    PUB --> MCP
 ```
 
 The strongest version of this system is evidence-backed at every layer. GenAI
 is not the foundation. It is the translation layer that turns telemetry into an
 operational explanation people can act on.
 
-## Capability Status Map
+## How This Differs From Typical AIOps Demos
+
+| Typical demo | Krystaline | Evidence |
+|---|---|---|
+| Summarize logs and hope for causality | Trace-first: baselines and RCA context are built from Jaeger spans, so causality across services is preserved | [`server/monitor/trace-profiler.ts`](server/monitor/trace-profiler.ts), [`server/monitor/context-enricher.ts`](server/monitor/context-enricher.ts) |
+| Ship telemetry to a cloud LLM API | Local-first: RCA runs on Ollama inside the compose stack, with an in-repo LoRA fine-tuning pipeline (r=16/α=32) | [`docker-compose.yml`](docker-compose.yml), [`axolotl-config.yaml`](axolotl-config.yaml) |
+| Put AI in the paging loop | Deterministic paging stays primary: 48 Prometheus alert rules in 11 groups route through Alertmanager and GoAlert; AI assists triage | [`config/alerting-rules.yml`](config/alerting-rules.yml), [`config/alertmanager.yml`](config/alertmanager.yml) |
+| Monitoring only | Monitoring plus cryptographic verifiability: 2 compiled Groth16 circuits with committed proving keys, a proof per filled trade, a 60-second solvency prover | [`server/circuits/`](server/circuits/), [`server/services/zk-proof-service.ts`](server/services/zk-proof-service.ts) |
+| A chatbot with screenshots | Agents get governed, read-only MCP tools — and can cryptographically verify a trade proof, not just read a status field | [`otel-mcp-server/src/tools/zk-proofs.ts`](otel-mcp-server/src/tools/zk-proofs.ts), [`server/mcp/index.ts`](server/mcp/index.ts) |
+
+## Capability Status
 
 | Capability | Status | Evidence / note |
 |---|---|---|
-| OpenTelemetry-first exchange flows | `[PUBLIC]` | Public docs describe trace-first trade, anomaly, and proof workflows. |
-| Distributed trace context over RabbitMQ | `[PUBLIC]` | Trace context is propagated through message headers for trade-path reconstruction. |
-| Unified observability dashboard | `[PUBLIC]` | Grafana dashboard assets, validation scripts, and monitoring docs live in this repo. |
-| Statistical anomaly detection | `[PUBLIC]` | Welford-based baselines and severity classification are documented and implemented. |
-| LLM-powered RCA metrics | `[PUBLIC]` | Public repo includes `kx_llm_analysis_total`, `kx_llm_analysis_duration_seconds`, `kx_llm_queue_depth`, and related dashboard panels. |
-| Bayesian root-cause inference | `[PUBLIC]` | Python/PyMC Bayesian service and TypeScript orchestration are present in the repo. |
-| Public proof APIs | `[PUBLIC]` | Public routes expose trade proof, verification, solvency, and proof-stat endpoints. |
-| Dedicated GenAI dashboard pack | `[CORE]` | Core contains GenAI Operations Core, AI RCA Reliability Matrix, and MCP Signal Lattice dashboards. |
-| Trace-centric RCA context builder | `[CORE]` | Core enriches alerts with traces, metrics, logs, topology, SLOs, and incident context. |
+| OpenTelemetry-first exchange flows; the browser is a traced service (`kx-wallet`, OTel Web SDK) | `[PUBLIC]` | [`server/otel.ts`](server/otel.ts), [`client/src/lib/otel.ts`](client/src/lib/otel.ts) |
+| Distributed trace context over RabbitMQ (dual W3C headers; reply re-joins the original HTTP trace) | `[PUBLIC]` | [`server/services/rabbitmq-client.ts`](server/services/rabbitmq-client.ts) |
+| Tail-based sampling: 4 explicit policies (errors, >500 ms, money-path services, 10% probabilistic); config validated in CI by the real collector binary | `[PUBLIC]` | [`config/otel-collector-config.yaml`](config/otel-collector-config.yaml) |
+| Statistical anomaly detection: severity ladder 3.0σ–8.0σ (MIN_SAMPLES=10), whale ladder 3–7σ, baselines frozen during chaos injection | `[PUBLIC]` | [`server/monitor/anomaly-detector.ts`](server/monitor/anomaly-detector.ts), [`server/monitor/chaos-controller.ts`](server/monitor/chaos-controller.ts) |
+| Trace-centric RCA context builder: fuses span critical path, Loki logs, topology blast radius, metrics, firing alerts, SLO status, and zk proof health from a single `traceId` | `[PUBLIC]` | [`server/monitor/context-enricher.ts`](server/monitor/context-enricher.ts) |
+| LLM RCA with a self-metered pipeline (5 `kx_llm_*` metric families) and an RLHF-style correction loop feeding LoRA fine-tuning | `[PUBLIC]` | [`server/monitor/stream-analyzer.ts`](server/monitor/stream-analyzer.ts), [`server/monitor/training-store.ts`](server/monitor/training-store.ts) |
+| Bayesian inference: hierarchical PyMC latency model plus a Noisy-OR alert-correlation network auto-trained from resolved incidents | `[PUBLIC]` | [`bayesian-service/`](bayesian-service/) |
+| zk proof system: 2 compiled Groth16 circuits with committed proving keys (977 / 1,256 wires), non-blocking proof per filled trade, 60-second solvency prover | `[PUBLIC]` | [`server/circuits/`](server/circuits/), [`server/services/zk-proof-service.ts`](server/services/zk-proof-service.ts) |
+| Public transparency API: status, anonymized trades, trace verification, proof fetch/verify/stats, solvency — no auth required | `[PUBLIC]` | [`server/api/public-routes.ts`](server/api/public-routes.ts) |
+| Deterministic self-healing: 4-action allowlist behind a kill switch with an audit trail; 4-stage price-feed escalation ladder | `[PUBLIC]` | [`server/monitor/auto-remediation.ts`](server/monitor/auto-remediation.ts), [`server/services/price-feed-manager.ts`](server/services/price-feed-manager.ts) |
+| Dashboards tested like code: an 834-line validator runs PromQL against live Prometheus; the unified dashboard has 73 panels / 79 targets | `[PUBLIC]` | [`scripts/validate-dashboard.js`](scripts/validate-dashboard.js), [`scripts/dashboard-integrity-monitor.js`](scripts/dashboard-integrity-monitor.js) |
+| Test posture: 1,100+ passing automated tests (1,088 main + 99 otel-mcp-server) | `[PUBLIC]` | [`tests/`](tests/), [`otel-mcp-server/tests/`](otel-mcp-server/tests/) |
+| Per-commit / CI enforcement of the confidential-doc scanner (it ships as the `precommit` script; no git hook or CI wiring installs it yet) | `[BACKLOG]` | [`scripts/check-confidential-docs.cjs`](scripts/check-confidential-docs.cjs) |
+| Dedicated GenAI dashboard pack (GenAI Operations Core, AI RCA Reliability Matrix, MCP Signal Lattice) | `[CORE]` | Core mission-control assets; see Dashboard Evidence Pack below. |
+| Deploy-time external LLM provider routing and governance | `[CORE]` | Local Ollama is the public default; enterprise provider controls stay private. |
 | Operator war-room assistant card | `[BACKLOG]` | Designed as the next service-manager workflow layer. |
 | Human-approved remediation actions | `[ASPIRATIONAL]` | Requires a separate approved-actions interface and audit controls. |
 | Replacing deterministic paging with AI | `[NON-GOAL]` | Alertmanager, GoAlert, and SLO rules remain the paging system of record. |
-
-## Evidence Snapshot
-
-| Signal | Current public story |
-|---|---|
-| Distributed traces | 17+ spans per trade-like flow with W3C context propagation. |
-| Anomaly detection | 168 hourly buckets using Welford's online algorithm and adaptive thresholds. |
-| AI diagnosis | Local-first Llama 3.2:1B RCA path with LoRA fine-tuning narrative and streaming structured analysis. |
-| Bayesian inference | Hierarchical PyMC service for uncertainty-aware root-cause ranking. |
-| Alerting | Prometheus and Alertmanager rules routed through GoAlert, ntfy, and email paths. |
-| Self-healing | Deterministic escalation ladder for feed recovery and Kubernetes restart behavior. |
-| Cryptographic proof | zk-SNARK trade integrity and solvency-proof concepts connected to traces. |
-| Test posture | 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server). |
-| Infrastructure | Docker Compose for local development; Helm and Kubernetes assets for deployed environments. |
 
 ## Thesis
 
@@ -201,7 +226,11 @@ reliability, and one for MCP/tool trace coverage.
 
 ![GenAI observability dashboard pack: GenAI Operations Core, AI RCA Reliability Matrix, and MCP Signal Lattice](docs/blog/assets/genai-observability-dashboard-pack.png)
 
-| Dashboard | Status | What it proves |
+These dashboards are Core assets; the screenshot above is the public evidence.
+The public-side equivalents are the `kx_llm_*` metric families in
+[`server/monitor/stream-analyzer.ts`](server/monitor/stream-analyzer.ts).
+
+| Dashboard | Status | What it shows |
 |---|---|---|
 | GenAI Operations Core | `[CORE]` | The GenAI provider path is observable: requests, latency, tokens, RCA throughput, queue pressure, and dropped events. |
 | AI RCA Reliability Matrix | `[CORE]` | RCA can be operated like production infrastructure: failure ratio, timeout ratio, p95/p99 latency, queue depth, and alert state. |
@@ -229,14 +258,19 @@ runbook context beside metrics, and "live evidence only" privacy posture.
 Most AI operations demos begin with log summarization. Krystaline starts with
 distributed traces because traces preserve causality across services. A single
 trade-like flow can be followed through browser, gateway, API, queue, matcher,
-settlement, and verification.
+settlement, and verification
+([`server/monitor/trace-profiler.ts`](server/monitor/trace-profiler.ts),
+[`server/monitor/context-enricher.ts`](server/monitor/context-enricher.ts)).
 
 ### 2. It combines statistical, probabilistic, and generative intelligence
 
 Statistical systems are better at saying "this is abnormal." Bayesian inference
 is useful for ranking likely causes under uncertainty. Language models are
 better at explaining "what this probably means" to a human. Krystaline keeps
-those responsibilities separate.
+those responsibilities separate
+([`server/monitor/baseline-calculator.ts`](server/monitor/baseline-calculator.ts),
+[`bayesian-service/`](bayesian-service/),
+[`server/monitor/analysis-service.ts`](server/monitor/analysis-service.ts)).
 
 ### 3. It treats GenAI as a production dependency
 
@@ -244,49 +278,28 @@ The AI path must itself be observable before it can explain the rest of the
 platform. Useful questions include: is the model endpoint healthy, are requests
 timing out, is queue depth increasing, are analyses being dropped, and which
 provider or model produced an answer?
+([`server/monitor/stream-analyzer.ts`](server/monitor/stream-analyzer.ts))
 
 ### 4. It uses MCP as an investigative interface
 
 The Model Context Protocol pattern gives an assistant disciplined access to
 read-only observability tools for traces, metrics, alerts, topology, proof
 status, and service health. Public tools expose public-safe data; operator
-tools can be deeper and still governed.
+tools can be deeper and still governed
+([`server/mcp/index.ts`](server/mcp/index.ts),
+[`otel-mcp-server/`](otel-mcp-server/)).
 
 ### 5. It connects observability to verifiability
 
-zk-SNARK trade integrity and solvency concepts are not a side quest. They make
-the trust story sharper: telemetry explains what happened operationally, while
-proof artifacts support integrity claims without exposing private data.
-
-## Current Reality Matrix
-
-| Area | Already there | Still backlog | Do not overclaim |
-|---|---|---|---|
-| Telemetry foundation | `[PUBLIC]` Trace, metric, log, dashboard, alerting, and proof documentation. | Keep expanding public examples and redacted evidence. | Claiming every private Core dashboard is shipped publicly. |
-| GenAI operations | `[PUBLIC]` Baseline LLM/RCA metrics and public thesis. `[CORE]` Dedicated GenAI dashboard pack. | Publish redacted dashboard stories when safe. | Claiming complete GenAI standards maturity while conventions are still evolving. |
-| RCA context | `[PUBLIC]` Context-enrichment concepts and code paths. `[CORE]` Full trace-centric context builder. | Improve public explanation without disclosing private prompts or internals. | Fully autonomous root-cause certainty. |
-| Service-manager workflow | `[PUBLIC]` Thesis and product narrative. | War-room card, follow-up thread, evidence trail, and chat delivery flow. | AI as incident commander. |
-| Provider strategy | `[CORE]` Local Ollama default plus controlled deploy-time external provider support. | Enterprise provider governance, cost controls, and tenant-safe key management. | Customer BYOK before scoped secrets and audit design are approved. |
-| Remediation | `[PUBLIC]` Deterministic self-healing and alert routing narrative. | Human-approved action surface. | Unapproved AI rollback, restart, or scale actions. |
-
-## Runtime Architecture
-
-```text
-Browser (React + OpenTelemetry SDK)
-  -> Kong API Gateway
-  -> Exchange API (Node/Express)
-  -> PostgreSQL, Redis, RabbitMQ
-  -> Order matching, wallet, proof, and monitoring flows
-  -> OpenTelemetry Collector
-  -> Jaeger, Prometheus, Loki, Grafana
-  -> Anomaly detection and severity classification
-  -> LLM RCA, Bayesian inference, Alertmanager, GoAlert
-  -> Operator dashboards, public proof APIs, and transparency surfaces
-```
-
-All material services are expected to emit telemetry. Traces carry W3C context
-through service boundaries so the system can reconstruct the path from user
-action to backend execution and proof status.
+The zk layer is not a side quest: two compiled Groth16 circuits with committed
+proving keys generate a proof for every filled trade — with the trade's OTel
+trace ID committed inside the Poseidon hash — plus a solvency proof regenerated
+on a 60-second timer (the reserve commitment is published; the proof is
+verified server-side). Telemetry explains what happened operationally, while
+proof artifacts support integrity claims without exposing private data
+([`server/circuits/trade_integrity.circom`](server/circuits/trade_integrity.circom),
+[`server/circuits/solvency.circom`](server/circuits/solvency.circom),
+[`server/services/zk-proof-service.ts`](server/services/zk-proof-service.ts)).
 
 ## Local Quick Start
 
@@ -295,7 +308,8 @@ npm install --legacy-peer-deps
 npm run dev
 ```
 
-Then open <http://localhost:5173>.
+Then open <http://localhost:5173>. See
+[See It in Five Minutes](#see-it-in-five-minutes) above for the guided path.
 
 Useful commands:
 
@@ -304,7 +318,7 @@ Useful commands:
 | `npm run check` | TypeScript check. |
 | `npm test` | Vitest unit suite. |
 | `npm run test:e2e:playwright` | Playwright browser tests. |
-| `npm run validate:dashboard` | Validate Grafana dashboard structure. |
+| `npm run validate:dashboard` | Validate Grafana dashboards against live Prometheus data. |
 | `npm run ci:check-docs` | Check public docs for confidential markers. |
 | `npm run docs:build` | Render diagrams and generate docs artifacts. |
 
@@ -337,7 +351,7 @@ see [Getting Started](docs/GETTING_STARTED.md).
 | Gateway | Kong with OpenTelemetry integration |
 | Observability | OpenTelemetry SDK and Collector, Jaeger, Prometheus, Loki, Grafana, Alertmanager |
 | Alerting | GoAlert, ntfy, email, SLO and burn-rate rules |
-| AI / ML | Ollama, Llama 3.2:1B, LoRA fine-tuning narrative, PyMC Bayesian service |
+| AI / ML | Ollama, Llama 3.2:1B, LoRA fine-tuning pipeline (r=16 / α=32), PyMC Bayesian service |
 | Cryptography | Circom, Groth16 zk-SNARK circuits, snarkjs |
 | Testing | Vitest, Playwright, smoke tests, dashboard validation |
 | Infrastructure | Docker Compose, Helm, Kubernetes |
@@ -353,39 +367,26 @@ see [Getting Started](docs/GETTING_STARTED.md).
 | [Demo Walkthrough](docs/product/03_DEMO_WALKTHROUGH.md) | Guided demo for the public lab. |
 | [Architecture](docs/architecture/01_ARCHITECTURE.md) | System design, data flow, component interactions. |
 | [Observability Whitepaper](docs/OBSERVABILITY_WHITEPAPER.md) | Philosophy, implementation, and mathematical foundations. |
-| [Anomaly Detection Design](docs/observability/02_ANOMALY_DETECTION_DESIGN.md) | Welford baselines, time buckets, and adaptive thresholds. |
+| [Anomaly Detection Design](docs/observability/02_ANOMALY_DETECTION_DESIGN.md) | Baselines, time buckets, and adaptive thresholds. |
 | [Bayesian Inference](docs/observability/05_BAYESIAN_INFERENCE.md) | Hierarchical models and dependency-aware root-cause analysis. |
 | [Fine-Tuning Guide](docs/observability/04_FINE_TUNING.md) | LoRA training pipeline and synthetic training-data generation. |
 | [K8s Deployment](docs/operations/02_DEPLOYMENT_K8S.md) | Helm charts, Kubernetes setup, and production configuration. |
 | [Runbook](docs/operations/04_RUNBOOK.md) | Operational procedures and incident response. |
 | [GoAlert Setup](docs/operations/GOALERT_SETUP.md) | On-call schedules, notification routing, and provisioning. |
 
-## What To Showcase Now
+## A Note on Naming
 
-| Showcase | Message |
-|---|---|
-| OpenTelemetry trade path | "Every important operation should leave a reconstructable telemetry trail." |
-| AI SRE thesis | "The model explains verified telemetry; it does not invent operational reality." |
-| Service-manager control | "The target user is also the owner who needs impact, evidence, and next action." |
-| GenAI dashboard pack | "The AI path is itself observable and governed." |
-| Crypto and DeFi fit | "Latency, traces, proofs, solvency, and transparency all become trust signals." |
-| Deterministic paging | "AI assists triage; Alertmanager and GoAlert remain the escalation backbone." |
-
-Use precise language:
-
-| Do say | Avoid saying |
-|---|---|
-| "The public lab demonstrates the observability-first architecture." | "All private Core capabilities are fully published here." |
-| "AI produces evidence-backed hypotheses." | "AI determines root cause with certainty." |
-| "Paging remains deterministic." | "AI replaces on-call." |
-| "Approved actions are a governed future phase." | "The AI can safely mutate production by itself." |
-| "External provider routing is a controlled deployment option." | "Customer BYOK is shipped." |
+Some runtime identifiers still use legacy names such as `krystalinex`, `kx-*`,
+or `kx_*` while public-facing prose moves to **Krystaline** and **Krystaline
+Observability Lab**. See [Brand Positioning](docs/BRAND_POSITIONING.md) for the
+naming policy.
 
 ## Contributing and Security
 
 Contributions should preserve the evidence-first posture: public claims need
 public evidence, sensitive internals stay private, and AI-assisted operations
-must keep deterministic control paths intact.
+must keep deterministic control paths intact. For messaging guidance, see
+[Brand Positioning](docs/BRAND_POSITIONING.md).
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md), and
 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before opening substantial changes.

--- a/docs/BRAND_POSITIONING.md
+++ b/docs/BRAND_POSITIONING.md
@@ -61,6 +61,33 @@ Avoid:
 - Claims that private Core functionality is fully present in the public repo.
 - Claims about customer-funds production readiness unless separately approved.
 
+## Showcase Messaging
+
+### What To Showcase Now
+
+Lead with capabilities that are demonstrable in the public lab today, each paired with its core message:
+
+| Showcase | Message |
+|---|---|
+| OpenTelemetry trade path | "Every important operation should leave a reconstructable telemetry trail." |
+| AI SRE thesis | "The model explains verified telemetry; it does not invent operational reality." |
+| Service-manager control | "The target user is also the owner who needs impact, evidence, and next action." |
+| GenAI dashboard pack | "The AI path is itself observable and governed." |
+| Crypto and DeFi fit | "Latency, traces, proofs, solvency, and transparency all become trust signals." |
+| Deterministic paging | "AI assists triage; Alertmanager and GoAlert remain the escalation backbone." |
+
+### Precise Language
+
+Use precise language:
+
+| Do say | Avoid saying |
+|---|---|
+| "The public lab demonstrates the observability-first architecture." | "All private Core capabilities are fully published here." |
+| "AI produces evidence-backed hypotheses." | "AI determines root cause with certainty." |
+| "Paging remains deterministic." | "AI replaces on-call." |
+| "Approved actions are a governed future phase." | "The AI can safely mutate production by itself." |
+| "External provider routing is a controlled deployment option." | "Customer BYOK is shipped." |
+
 ## Migration Policy
 
 This rebrand is intentionally two-speed:

--- a/docs/architecture/01_ARCHITECTURE.md
+++ b/docs/architecture/01_ARCHITECTURE.md
@@ -1,167 +1,187 @@
-# Krystaline Observability Lab Architecture & Repository Map
+# Krystaline Architecture
 
-## System Overview
+Krystaline is a cryptocurrency exchange built so that every material flow can be independently checked: each trade is traced end-to-end (starting in the user's browser), analyzed for anomalies against learned baselines, and cryptographically bound to a zero-knowledge proof that commits to the OTel trace ID itself. The system is four cooperating planes — **Exchange flow**, **Telemetry**, **Analysis**, and **Proof & agent access** — all of which ship in this repository. Claims below carry evidence tags: [PUBLIC] means the code is in this repo, one click away. Where a number appears, it was measured or counted from the committed source, not estimated.
 
-This repository demonstrates OpenTelemetry context propagation using a cryptocurrency exchange system with Kong API Gateway, RabbitMQ messaging, and blockchain-style wallet addresses (`kx1...`).
+## Repository layout
 
-## Architecture Diagram
+```
+client/                  React frontend (kx-wallet) — OTel Web SDK in src/lib/otel.ts
+server/
+  api/                   REST routes; public-routes.ts is the unauthenticated transparency API
+  core/                  order-service.ts — validation, settlement, zk trigger
+  services/              rabbitmq-client.ts, zk-proof-service.ts, kong-client.ts,
+                         price-feed-manager.ts
+  monitor/               anomaly detection, baselines, LLM RCA, chaos, remediation (20 files)
+  bayesian/              Node client for the Python Bayesian service
+  circuits/              Circom sources + committed Groth16 build artifacts
+  mcp/                   embedded MCP server (28 tools)
+  otel.ts                NodeSDK bootstrap — imported first
+payment-processor/       kx-matcher — standalone order matcher
+bayesian-service/        Python FastAPI — PyMC + Noisy-OR engines
+otel-mcp-server/         standalone MCP server package (32 tools, v1.2.0)
+config/                  collector, Prometheus, Alertmanager, alerting rules, Grafana provisioning
+scripts/                 start-dev.js, dashboard validators, e2e-test.js
+docker-compose.yml       22 infrastructure services
+axolotl-config.yaml      LoRA fine-tune config (r=16, α=32)
+```
+
+## Four planes
+
+### 1. Exchange flow [PUBLIC]
+
+The trading system itself: three Node processes run natively on the host, backed by 22 Docker Compose services ([`docker-compose.yml`](../../docker-compose.yml)) for infrastructure (Kong + its Postgres + a run-once Kong migrations job, RabbitMQ, app PostgreSQL on host port 5433, Redis, Jaeger, OTel Collector, Prometheus, Alertmanager, Grafana, Loki, Promtail, Ollama, GoAlert + its Postgres, MailDev, bayesian-service, and 4 metrics exporters).
+
+- **Frontend** (`kx-wallet`) — Vite/React on :5173 ([`client/src`](../../client/src)). The browser is a first-class traced service: [`client/src/lib/otel.ts`](../../client/src/lib/otel.ts) boots the OTel Web SDK, and the trade form opens a client span `order.submit.client` ([`client/src/components/trade-form.tsx`](../../client/src/components/trade-form.tsx)), so traces begin in the user's browser, not at the load balancer.
+- **API server** (`kx-exchange`) — Express on :5000 ([`server/index.ts`](../../server/index.ts)). Registers itself with Kong at startup ([`server/services/kong-client.ts`](../../server/services/kong-client.ts)); rate limits are 300/60/15 requests per IP per 60 s for general/auth/sensitive routes ([`server/middleware/security.ts`](../../server/middleware/security.ts)).
+- **Order matcher** (`kx-matcher`) — a standalone process ([`payment-processor/index.ts`](../../payment-processor/index.ts)) consuming a durable RabbitMQ queue, simulating fills with 0.01–0.5% slippage and replying on a response queue.
+- **Order path** — `POST /api/v1/orders` → [`server/core/order-service.ts`](../../server/core/order-service.ts) validates wallets, then [`server/services/rabbitmq-client.ts`](../../server/services/rabbitmq-client.ts) publishes and blocks up to 5 s (behind a circuit breaker, failure threshold 3) on an exclusive per-instance reply queue — the exclusive queue exists so multiple API replicas can each receive their own responses. On FILLED: wallet settlement, then a **non-blocking** zk proof (`.catch`-guarded fire-and-forget at [`server/core/order-service.ts:286-294`](../../server/core/order-service.ts) — order flow never waits on proving).
+- **Dev topology** — `npm run dev` ([`scripts/start-dev.js`](../../scripts/start-dev.js)) composes 21 of the 22 infrastructure services (all except bayesian-service), waits for Kong/RabbitMQ/Postgres health, enables Kong's OpenTelemetry and CORS plugins, then starts the API, matcher, and Vite in order. See [Getting Started](../GETTING_STARTED.md) for the 5-minute walkthrough ending in a verified proof.
+
+### 2. Telemetry [PUBLIC]
+
+Every hop emits OpenTelemetry; a full RabbitMQ trade trace typically shows 17+ spans across 4 services (kx-wallet → api-gateway → kx-exchange → kx-matcher, observed in demo traces).
+
+- **Server SDK** — [`server/otel.ts`](../../server/otel.ts) boots the NodeSDK before any other import (ESM import-in-the-middle hook), with two span processors: a `SimpleSpanProcessor` feeding an in-process trace collector (last 100 business spans, for the local UI) and a `BatchSpanProcessor` exporting OTLP/HTTP. Auto-instrumentation covers HTTP and amqplib; `fs` and `undici` are disabled to cut noise. An `ignoreOutgoingRequestHook` (lines 148–161) drops spans for the system's own Jaeger/Prometheus polling so the anomaly detector can never flag its own monitoring loop.
+- **Browser SDK** — the frontend exports OTLP/HTTP to the collector on :4319, so a trade trace's root span is created client-side before the request leaves the browser.
+- **Broker propagation** — dual W3C context over RabbitMQ: the publisher injects both a `traceparent` (consumer parenting) and `x-parent-traceparent` (the original POST span context); the matcher echoes the POST context back as the reply's `traceparent`, so the async continuation — wallet update, zk proof spans — stitches into the original HTTP trace ([`server/services/rabbitmq-client.ts:183-212, 289-313`](../../server/services/rabbitmq-client.ts), [`payment-processor/index.ts:170-193, 260-268`](../../payment-processor/index.ts)).
+- **Collector** — tail-based sampling with 4 explicit policies: keep all ERROR traces, all traces >500 ms, all traces touching kx-matcher/payment-processor, 10% probabilistic for the rest ([`config/otel-collector-config.yaml:35-55`](../../config/otel-collector-config.yaml)). CI validates this exact file with the real collector binary (`otel/opentelemetry-collector-contrib:0.120.0 validate`, [`.github/workflows/ci.yml:86-90`](../../.github/workflows/ci.yml)).
+- **Metrics, logs, alerts** — Prometheus (12 h/2 GB retention, exemplar storage enabled) scrapes the app, the matcher's own metrics server on :3001, RabbitMQ, and four exporters (postgres, kong-postgres, node, redis); pino ships logs to Loki alongside Promtail. 48 alert rules in 11 groups ([`config/alerting-rules.yml`](../../config/alerting-rules.yml)) route through Alertmanager ([`config/alertmanager.yml`](../../config/alertmanager.yml)): critical → GoAlert + email + ntfy.sh push; `PriceFeedUnavailable` additionally hits the app's auto-remediation webhook; inhibition rules suppress warnings when the same service is critical.
+- **Grafana provisioned from the repo** — 3 datasources with cross-links (Prometheus exemplars → Jaeger, Loki traceId-derived fields, Jaeger tracesToLogs/tracesToMetrics) and 5 dashboards, the largest being the unified dashboard with 73 panels backed by 79 query targets ([`config/grafana/provisioning/`](../../config/grafana/provisioning)).
+- **Dashboards tested like code** — an 834-line validator executes every panel's PromQL against live Prometheus (data presence, query health, freshness, cross-panel invariants) with CI exit codes ([`scripts/validate-dashboard.js`](../../scripts/validate-dashboard.js)), and a 405-line integrity monitor pushes five `kx_dashboard_*` meta-metrics ([`scripts/dashboard-integrity-monitor.js`](../../scripts/dashboard-integrity-monitor.js)).
+
+### 3. Analysis [PUBLIC]
+
+Twenty files under [`server/monitor/`](../../server/monitor) plus a Python Bayesian microservice. The key components:
+
+- **[`trace-profiler.ts`](../../server/monitor/trace-profiler.ts)** — polls Jaeger every 30 s, builds per-span duration baselines; freezable during chaos injection.
+- **[`baseline-calculator.ts`](../../server/monitor/baseline-calculator.ts)** — time-aware baselines per (service:operation × day-of-week × hour-of-day) — 168 buckets per span key — with adaptive severity thresholds learned from empirical 80/90/95/99/99.9th percentiles of positive deviations, a 4-level bucket fallback chain, and incremental recomputation from a per-service DB watermark.
+- **[`anomaly-detector.ts`](../../server/monitor/anomaly-detector.ts)** — 10 s checks; default severity ladder SEV5=3.0σ → SEV1=8.0σ, MIN_SAMPLES=10.
+- **[`amount-profiler.ts`](../../server/monitor/amount-profiler.ts)** + amount-anomaly-detector — whale detection on trade amounts using Welford's online algorithm (mean/variance), ladder 3σ–7σ.
+- **[`stream-analyzer.ts`](../../server/monitor/stream-analyzer.ts)** — batches anomalies to a local Ollama LLM; the AI layer is itself observed via 5 `kx_llm_*` Prometheus metric families (pre-initialized to zero) and a bounded queue (MAX_QUEUE_SIZE=100) that sheds load with a labeled drop counter.
+- **[`context-enricher.ts`](../../server/monitor/context-enricher.ts)** — the trace-centric RCA context builder: from a single traceId it fuses span critical path, correlated Loki logs, Jaeger topology/blast radius, Prometheus metrics at trace time, firing alerts, SLO/error-budget status, and zk proof health into one RCA context.
+- **[`auto-remediation.ts`](../../server/monitor/auto-remediation.ts)** — a 4-action allowlist behind an `AUTO_REMEDIATION_ENABLED` kill switch with an audit trail at `/remediation/history`; the price feed has a 4-stage escalation ladder (15 s soft reconnect → 30 s failover → 45 s reconnect-all → 60 s+ K8s liveness-driven restart) exported as a Prometheus gauge ([`server/services/price-feed-manager.ts`](../../server/services/price-feed-manager.ts)).
+- **[`chaos-controller.ts`](../../server/monitor/chaos-controller.ts)** — API-key-gated fault injection that freezes baselines for the duration.
+- **[`training-store.ts`](../../server/monitor/training-store.ts)** — RLHF-style loop: operator-corrected analyses export as JSONL (human correction = training completion, model's original kept as `original_completion`), feeding the Axolotl LoRA config in the repo root ([`axolotl-config.yaml`](../../axolotl-config.yaml): Llama-3.2-1B-Instruct, r=16, α=32).
+- **Supporting components** — [`topology-service.ts`](../../server/monitor/topology-service.ts) (Jaeger dependency graph + BFS blast radius), [`metrics-correlator.ts`](../../server/monitor/metrics-correlator.ts) (Prometheus correlation at anomaly time), [`history-store.ts`](../../server/monitor/history-store.ts) (baselines/anomalies persisted to PostgreSQL via Drizzle), [`alertmanager-notifier.ts`](../../server/monitor/alertmanager-notifier.ts) (posts SEV1–3 anomalies as standard Alertmanager v2 alerts, auto-resolving after 5 min), and [`ws-server.ts`](../../server/monitor/ws-server.ts) (streams analysis over `/ws/monitor`).
+
+**Two Bayesian engines** run side by side in [`bayesian-service/`](../../bayesian-service) (FastAPI, :8100): a hierarchical PyMC latency model (global hyperpriors → per-service Normal/HalfNormal, MCMC with 500 draws, analytical conjugate fallback) and a Noisy-OR alert-correlation network that an autonomous poller auto-trains every 30 s from resolved incidents enriched with Prometheus exemplar trace IDs ([`bayesian-service/app/models.py`](../../bayesian-service/app/models.py), [`bayesian-service/app/poller.py`](../../bayesian-service/app/poller.py)). The Node side integrates via [`server/bayesian/`](../../server/bayesian).
+
+### 4. Proof & agent access [PUBLIC]
+
+- **Circuits** — two Circom 2.0 circuits with committed Groth16 artifacts in [`server/circuits/build/`](../../server/circuits/build):
+  - [`trade_integrity.circom`](../../server/circuits/trade_integrity.circom) proves `tradeHash == Poseidon(fillPrice, quantity, userId, timestamp, traceId)` with a `priceLow ≤ fillPrice ≤ priceHigh` range check. The OTel 128-bit trace ID (converted to a field element) is a private witness input, so **swapping the trace invalidates the proof** — this is the bind between the observability plane and the proof plane.
+  - [`solvency.circom`](../../server/circuits/solvency.circom) proves `SUM(balances) == claimedTotal ≥ threshold` with a Poseidon reserve commitment, without revealing individual balances; solvency proofs regenerate on a timer.
+  - Circuit sizes are statically verifiable from the committed zkey headers: 977 wires (trade, 425,302 B proving key) and 1,256 wires (solvency, 578,660 B).
+- **Proving pipeline** — [`server/services/zk-proof-service.ts`](../../server/services/zk-proof-service.ts) records `zk.prove` / `zk.witness.generate` / `zk.proof.generate` / `zk.proof.verify` spans *inside the same trade trace* it is proving, so the proof of the trade and the act of proving are visible in one Jaeger view. Publicly exposed signals are only `tradeHash`, `priceLow`, `priceHigh` (±0.5% of the Binance reference price); fill price, quantity, user, timestamp, and traceId stay private witness inputs — best execution is provable without leaking the fill. Measured in a 2026-07-05 benchmark run against the committed artifacts: warm proving 129–152 ms, verification 12–20 ms, 724-byte serialized proof JSON.
+- **Public transparency API** — unauthenticated, mounted at `/api/v1/public` and `/api/public` ([`server/api/public-routes.ts`](../../server/api/public-routes.ts)): `/status`, `/trades`, `/trace/:traceId`, `/zk/proof/:tradeId`, `/zk/verify/:tradeId` (server-side `snarkjs.groth16.verify()` against the committed verification key), `/zk/stats`, `/zk/solvency`.
+- **MCP servers** — two:
+  - The **embedded** server ([`server/mcp/index.ts`](../../server/mcp/index.ts)) registers 28 tools against the running exchange: 5 trace tools (`traces_*` + `trace_get`), 6 `metrics_*`, 4 `logs_*`, 4 `zk_*`, 2 `anomalies_*`, plus system health/topology, `bayesian_train`/`bayesian_insights`/`bayesian_health`, and alert-RCA tools. Run via `npm run mcp` (stdio) or `mcp:http` on :3100.
+  - The **standalone** [`otel-mcp-server/`](../../otel-mcp-server) v1.2.0 is its own package (own tests and CHANGELOG) with 32 tools across 7 skill plugins — traces (5, Jaeger), metrics (6, Prometheus), logs (4, Loki), Elasticsearch (5), Alertmanager (4), zk-proofs (4), system (4) — selectable via a `--tools` flag, so it works against any OTel stack, not just this one.
+  - The verification path is real: an agent calling `zk_proof_verify` ([`otel-mcp-server/src/tools/zk-proofs.ts`](../../otel-mcp-server/src/tools/zk-proofs.ts)) hits `GET /api/public/zk/verify/:tradeId`, whose handler runs `snarkjs.groth16.verify()` against the committed verification key and returns the mathematical verdict — not a status-page assertion.
+
+Test coverage across the planes: 1,100+ passing tests per the README (1,088 main suite + 99 in otel-mcp-server) [PUBLIC — counts as reported in [`README.md`](../../README.md)].
+
+## Trade lifecycle, end to end
 
 ```mermaid
 graph TB
-    subgraph "Frontend Layer"
-        UI["React App<br/>(client/src)"]
+    subgraph EXCHANGE ["Exchange flow"]
+        BROWSER["kx-wallet (browser)<br/>order.submit.client span"]
+        KONG["Kong Gateway :8000<br/>OTel plugin"]
+        API["kx-exchange (Express :5000)<br/>order-service.ts"]
+        MQ[("RabbitMQ<br/>traceparent + x-parent-traceparent")]
+        MATCHER["kx-matcher<br/>payment-processor/index.ts"]
+        WALLET["Wallet settlement"]
     end
 
-    subgraph "Gateway Layer"
-        KONG["Kong API Gateway<br/>(docker-compose.external.yml)"]
+    subgraph PROOF ["Proof & agent access"]
+        ZK["zk-proof-service.ts<br/>Groth16, non-blocking"]
+        PUBAPI["Public API<br/>/api/public/zk/verify/:tradeId"]
+        MCP["MCP servers<br/>embedded (28 tools) + otel-mcp-server (32 tools)"]
+        AGENT["AI agent / auditor"]
     end
 
-    subgraph "Application Layer"
-        EXPRESS["Express Server<br/>(server/index.ts)"]
-        ROUTES["API Routes<br/>(server/api/routes.ts)"]
-        ORDERS["OrderService<br/>(server/core/order-service.ts)"]
+    subgraph TELEMETRY ["Telemetry"]
+        COLLECTOR["OTel Collector<br/>tail sampling: 4 policies"]
+        JAEGER["Jaeger"]
+        PROM["Prometheus + Alertmanager<br/>48 rules / 11 groups"]
+        LOKI["Loki"]
     end
 
-    subgraph "Order Matcher Microservice"
-        MATCHER["Order Matcher<br/>(payment-processor/index.ts)"]
+    subgraph ANALYSIS ["Analysis"]
+        PROFILER["trace-profiler + baseline-calculator<br/>168 time buckets/span key"]
+        DETECTOR["anomaly-detector 3σ–8σ<br/>amount-profiler (whale 3σ–7σ)"]
+        LLM["stream-analyzer → Ollama<br/>+ context-enricher RCA"]
+        BAYES["bayesian-service<br/>PyMC + Noisy-OR"]
+        REMED["auto-remediation<br/>4-action allowlist"]
     end
 
-    subgraph "Message Queues"
-        ORDERS_Q["orders queue"]
-        RESPONSE_Q["order_response queue"]
-    end
+    BROWSER --> KONG --> API
+    API -->|publish, blocks ≤5s| MQ
+    MQ --> MATCHER
+    MATCHER -->|reply echoes POST context| MQ
+    MQ --> API
+    API --> WALLET
+    API -.->|"fire-and-forget on FILLED<br/>zk spans join same trace"| ZK
+    ZK --> PUBAPI
 
-    subgraph "Observability Layer"
-        OTEL["OTEL SDK<br/>(server/otel.ts)"]
-        COLLECTOR["OTEL Collector<br/>(otel-collector-config.yaml)"]
-        JAEGER["Jaeger<br/>(docker-compose.external.yml)"]
-    end
-
-    UI -->|HTTP POST| KONG
-    KONG -->|Proxy + Context Injection| EXPRESS
-    EXPRESS --> ROUTES
-    ROUTES --> ORDERS
-    ORDERS -->|publish| ORDERS_Q
-    ORDERS_Q -->|consume| MATCHER
-    MATCHER -->|ACK response| RESPONSE_Q
-    RESPONSE_Q -->|consume| EXPRESS
-    OTEL -->|Traces| COLLECTOR
+    BROWSER & API & MATCHER & ZK -->|OTLP| COLLECTOR
     COLLECTOR --> JAEGER
+    API --> PROM
+    API --> LOKI
+
+    JAEGER --> PROFILER --> DETECTOR --> LLM
+    PROM --> BAYES
+    PROM -->|Alertmanager webhook| REMED
+
+    AGENT --> MCP
+    MCP --> JAEGER & PROM & LOKI
+    MCP -->|zk_proof_verify| PUBAPI
 ```
 
-## Repository Structure
+## Why this design
 
-```
-krystaline-exchange/
-├── client/                     # Frontend React Application
-│   └── src/
-│       ├── App.tsx            # Main app component
-│       ├── pages/             # Page components (Dashboard, Trade)
-│       ├── components/        # UI components (shadcn/ui)
-│       ├── hooks/             # React hooks
-│       └── lib/               # Utilities (queryClient, utils, otel)
-│
-├── server/                     # Backend Express Application
-│   ├── index.ts               # App entrypoint, middleware setup
-│   ├── otel.ts                # OpenTelemetry SDK configuration
-│   ├── storage.ts             # In-memory data storage with kx1 wallets
-│   ├── vite.ts                # Vite dev server integration
-│   ├── api/
-│   │   └── routes.ts          # REST API endpoints
-│   ├── core/
-│   │   └── order-service.ts   # Order matching business logic
-│   ├── wallet/
-│   │   └── wallet-service.ts  # Wallet management with kx1 addresses
-│   └── services/
-│       ├── kong-client.ts     # Kong Gateway client
-│       └── rabbitmq-client.ts # RabbitMQ producer/consumer
-│
-├── shared/
-│   └── schema.ts              # Zod schemas (Order, Wallet, Transfer)
-│
-├── scripts/
-│   ├── start-dev.js           # Development startup script
-│   ├── e2e-test.js            # Automated E2E tests
-│   ├── enable-kong-otel.js    # Kong OTEL plugin config
-│   └── enable-kong-cors.js    # Kong CORS plugin config
-│
-├── .github/
-│   └── workflows/
-│       └── e2e-tests.yml      # GitHub Actions CI pipeline
-│
-├── docker-compose.yml          # Docker services (Kong, RabbitMQ, Jaeger, etc.)
-└── package.json                # Node dependencies and scripts
-```
+- **The RabbitMQ hop exists to prove context survives a broker boundary.** A synchronous monolith would be simpler; the point is demonstrating the dual-context pattern — `traceparent` for consumer parenting plus `x-parent-traceparent` so the reply re-enters the original POST trace ([`server/services/rabbitmq-client.ts:183-212`](../../server/services/rabbitmq-client.ts), [`payment-processor/index.ts:260-268`](../../payment-processor/index.ts)).
+- **Tail-based sampling, because head sampling loses exactly the traces you need.** The collector decides after seeing the whole trace: errors, >500 ms latency, and anything touching the money path are always kept ([`config/otel-collector-config.yaml:35-55`](../../config/otel-collector-config.yaml)). A missing trade trace would break the zk proof's verifiability story.
+- **Deterministic paging stays primary; AI is a translation layer.** Alerting runs on Prometheus rules → Alertmanager → GoAlert ([`config/alertmanager.yml`](../../config/alertmanager.yml)); the LLM enriches and explains but never gates a page. The anomaly detector posts into the same Alertmanager pipeline ([`server/monitor/alertmanager-notifier.ts`](../../server/monitor/alertmanager-notifier.ts)) rather than owning its own escalation path.
+- **Local-first LLM for zero egress.** RCA runs on Ollama in Compose ([`docker-compose.yml`](../../docker-compose.yml)); trace and trade data never leave the machine, and the LoRA fine-tuning path ([`axolotl-config.yaml`](../../axolotl-config.yaml)) keeps improvement local too.
+- **The observer must not observe itself.** An `ignoreOutgoingRequestHook` drops spans for the system's own Jaeger/Prometheus polling ([`server/otel.ts:148-161`](../../server/otel.ts)) — without it, the anomaly detector's 30 s polling loop would appear in traces and could flag itself.
+- **Baselines freeze during chaos.** The chaos controller calls `freezeBaselines()` on scenario start and unfreezes on stop ([`server/monitor/trace-profiler.ts:34-48`](../../server/monitor/trace-profiler.ts), [`server/monitor/chaos-controller.ts`](../../server/monitor/chaos-controller.ts)), so injected faults are detected against pre-chaos normals instead of contaminating what "normal" means — a chaos experiment must not teach the system that broken is normal.
 
-## Key Objects & Their Responsibilities
+## Verify it yourself
 
-### Domain Objects (shared/schema.ts)
+The architecture claims above are checkable against a running dev stack (`npm run dev`, then trade once):
 
-| Object | Purpose |
-|--------|---------|
-| `Payment` | Payment transaction record with amount, currency, recipient |
-| `Trace` | Distributed trace metadata (traceId, rootSpanId, status) |
-| `Span` | Individual span within a trace (operationName, serviceName, duration) |
-| `User` | User authentication data (not currently used) |
+| Claim | Check |
+|---|---|
+| Traces start in the browser | Open Jaeger (http://localhost:16686), find the trade trace — the root span is `order.submit.client` from service `kx-wallet` |
+| Context survives RabbitMQ | Same trace: publish, consume (`kx-matcher`), reply, and wallet-settlement spans share one trace ID |
+| zk proving lives inside the trade trace | Same trace again: `zk.prove` → `zk.proof.verify` spans appear after settlement |
+| Proof is real Groth16 | `curl http://localhost:5000/api/public/zk/verify/<tradeId>` — the server runs `snarkjs.groth16.verify()`; the proof and verification key are also downloadable for client-side verification |
+| E2E, by machine | [`scripts/e2e-test.js`](../../scripts/e2e-test.js) mints a random 128-bit trace ID client-side, sends it through Kong, and asserts that exact ID appears in Jaeger with ≥3 spans (manually-triggered CI workflow) |
+| Collector config is valid | CI runs the real collector binary's `validate` against [`config/otel-collector-config.yaml`](../../config/otel-collector-config.yaml) |
 
-### Server Components
+## Known limits (stated, not hidden)
 
-| Component | File | Responsibility |
-|-----------|------|----------------|
-| `Express App` | `server/index.ts` | HTTP server, middleware, lifecycle |
-| `OTEL SDK` | `server/otel.ts` | Trace collection, span processing, batch export |
-| `API Routes` | `server/api/routes.ts` | REST endpoints: POST /payments, GET /traces |
-| `PaymentService` | `server/core/payment-service.ts` | Payment validation, storage, queue publishing |
-| `KongClient` | `server/services/kong-client.ts` | Kong service/route configuration |
-| `RabbitMQClient` | `server/services/rabbitmq-client.ts` | Message publishing with W3C trace context |
-| `MemoryStorage` | `server/storage.ts` | In-memory data store for payments, traces |
+In keeping with the evidence-tag posture, the honest caveats of the current architecture:
 
-### Infrastructure Components
+- The **bayesian-service container is not started by `npm run dev`** — run `docker compose up bayesian-service` separately. [PUBLIC]
+- The matcher still consumes the **legacy `payments` / `payment_response` queue names**; the newer `orders` / `order_response` queues are asserted but not yet the active path ([`payment-processor/index.ts`](../../payment-processor/index.ts), [`server/config/index.ts`](../../server/config/index.ts)). [PUBLIC]
+- **Zk proof performance figures are runtime measurements**, not committed benchmark artifacts; wire counts and key sizes are the statically verifiable part. [PUBLIC]
+- The **E2E trace-assertion suite runs on manual trigger** (`workflow_dispatch`), not per-PR ([`.github/workflows/e2e-tests.yml`](../../.github/workflows/e2e-tests.yml)). [PUBLIC]
+- **Fills are simulated** with 0.01–0.5% slippage in the matcher — this is an observability lab around a realistic trade path, not a production matching engine ([`payment-processor/index.ts`](../../payment-processor/index.ts)). [PUBLIC]
 
-| Component | Config File | Purpose |
-|-----------|-------------|---------|
-| Kong Gateway | `docker-compose.external.yml` | API gateway, context injection |
-| RabbitMQ | `docker-compose.external.yml` | Message queue |
-| OTEL Collector | `otel-collector-config.yaml` | Trace aggregation, routing |
-| Jaeger | `docker-compose.yml` | Trace visualization |
-| Prometheus | `prometheus.yml` | Metrics collection |
+## Where to go deeper
 
-## Data Flow
-
-### Payment Request Flow
-```
-1. UI submits payment form
-2. Request goes to Kong Gateway (port 8000)
-3. Kong injects/preserves trace context (traceparent header)
-4. Kong proxies to Express server (port 5000)
-5. Express processes with OTEL auto-instrumentation
-6. PaymentService creates payment record
-7. RabbitMQClient publishes message with trace context
-8. Consumer receives and processes message
-9. All spans exported to OTEL Collector → Jaeger
-```
-
-### Trace Context Propagation
-```
-Mode 1 (Empty Headers): UI → Kong (creates traceparent) → API → RabbitMQ
-Mode 2 (Client Headers): UI (creates traceparent) → Kong (preserves) → API → RabbitMQ
-```
-
-## NPM Scripts
-
-| Script | Purpose |
-|--------|---------|
-| `npm run dev` | Start all services (Docker + Express + Vite) |
-| `npm run dev:server` | Start Express server only |
-| `npm run test:e2e` | Run automated E2E tests |
-| `npm run build` | Build for production |
-
-## Key Configurations
-
-| File | Purpose |
-|------|---------|
-| `package.json` | Dependencies, scripts |
-| `tsconfig.json` | TypeScript config |
-| `vite.config.ts` | Vite bundler config |
-| `tailwind.config.ts` | Tailwind CSS config |
-| `docker-compose.external.yml` | Docker services |
+| Topic | Document |
+|---|---|
+| Run it in 5 minutes | [Getting Started](../GETTING_STARTED.md) |
+| OTel instrumentation & propagation details | [OTel Tracing Guide](../observability/01_OTEL_TRACING_GUIDE.md) |
+| Anomaly detection design (baselines, severity, whales) | [Anomaly Detection Design](../observability/02_ANOMALY_DETECTION_DESIGN.md) |
+| Bayesian inference (PyMC + Noisy-OR) | [Bayesian Inference](../observability/05_BAYESIAN_INFERENCE.md) |
+| LoRA fine-tuning pipeline | [Fine-Tuning](../observability/04_FINE_TUNING.md) |
+| Full observability rationale | [Observability Whitepaper](../OBSERVABILITY_WHITEPAPER.md) |
+| Chaos injection scenarios | [Chaos Injection](../CHAOS_INJECTION.md) |
+| Questions agents can answer over MCP | [MCP Top 20 Questions](../MCP_TOP_20_QUESTIONS.md) |
+| Docker deployment | [Deployment (Docker)](../operations/01_DEPLOYMENT_DOCKER.md) |
+| Kubernetes deployment | [Deployment (K8s)](../operations/02_DEPLOYMENT_K8S.md) |

--- a/docs/architecture/04_TECHNICAL_ASSESSMENT.md
+++ b/docs/architecture/04_TECHNICAL_ASSESSMENT.md
@@ -1,5 +1,5 @@
 # Krystaline Technical Assessment
-> **Generated:** 2026-02-06  
+> **Generated:** 2026-07-05 — re-verified against code  
 > **Assessment Method:** Static review + prior test results (tests not rerun this pass)  
 > **Status:** ⚠️ Partially verified (see testing section)
 
@@ -7,7 +7,7 @@
 
 ## Executive Summary
 
-Krystaline is a **demo-ready crypto exchange platform** with exceptional observability, security, and monitoring capabilities. The backend demonstrates professional-grade engineering with extensive test coverage (1,100+ passing automated tests: 1,088 in the main suite + 99 in otel-mcp-server), proper security middleware, and a sophisticated anomaly detection system. The frontend requires polish for production but is sufficient for investor demos.
+Krystaline is a **demo-ready crypto exchange platform** whose observability and security posture is measurable rather than claimed: 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server), 48 alert rules across 11 groups, a unified dashboard with 73 panels / 79 query targets, three-tier rate limiting (300/60/15 req/min), and a statistical anomaly detection pipeline with a 3.0σ–8.0σ severity ladder ([server/monitor/anomaly-detector.ts](../../server/monitor/anomaly-detector.ts)). The frontend requires polish for production but is sufficient for investor demos.
 
 ### Overall Health Score: **83/100**
 
@@ -148,16 +148,20 @@ Helmet configured with:
 server/
 ├── api/          # Route handlers (health, public, routes)
 ├── auth/         # Authentication service & routes
+├── circuits/     # Circom ZK circuits (solvency, trade_integrity) + compiled build artifacts
 ├── config/       # Centralized Zod-validated config
 ├── core/         # Core services (order, payment)
 ├── db/           # PostgreSQL connection & storage
 ├── lib/          # Utilities (errors, logger)
+├── mcp/          # Embedded MCP server (28 telemetry tools over stdio/HTTP)
 ├── metrics/      # Prometheus instrumentation
 ├── middleware/   # Security, error handling, request logging
-├── monitor/      # Anomaly detection, baseline calc, streaming
-├── services/     # External integrations (Kong, RabbitMQ, Binance)
+├── monitor/      # Anomaly detection pipeline (20 modules, see Observability Assessment)
+├── services/     # External integrations (Kong, RabbitMQ, Binance) + ZK proof service
 ├── trade/        # Trading service & routes
 └── wallet/       # Wallet service & routes
+
+otel-mcp-server/  # Standalone, separately-tested MCP server package (99 tests)
 ```
 
 ### ✅ Health Endpoints (IMPLEMENTED)
@@ -215,19 +219,26 @@ server/
 
 | Component | Purpose | Status |
 |-----------|---------|--------|
-| `anomaly-detector.ts` | Statistical anomaly detection | ✅ |
+| `anomaly-detector.ts` | Z-score detection on span durations, 3.0σ (SEV5) → 8.0σ (SEV1), MIN_SAMPLES=10 | ✅ |
 | `baseline-calculator.ts` | Time-based baseline computation | ✅ |
-| `stream-analyzer.ts` | Real-time trace analysis | ✅ |
+| `stream-analyzer.ts` | Batches anomalies (max 10 per batch / 30s window, queue cap 100) into streamed Ollama analysis; 9 tiered use-case prompts; exports 5 `kx_llm_*` Prometheus self-metrics | ✅ |
 | `trace-profiler.ts` | Span performance profiling | ✅ |
 | `metrics-correlator.ts` | Cross-signal correlation | ✅ |
-| `history-store.ts` | Persistent anomaly history | ✅ |
+| `history-store.ts` | PostgreSQL-backed baseline/anomaly persistence (survives restart; analyses cached in memory, last 1,000) | ✅ |
+| `context-enricher.ts` + `analysis-service.ts` | Trace-centric RCA: from a traceId, parallel-fetches spans, Loki logs (±5 min), Prometheus metrics at trace time, firing alerts, SLO budgets, topology blast radius (BFS), and ZK health into a single LLM prompt | ✅ |
+| `amount-profiler.ts` + `amount-anomaly-detector.ts` | Whale/amount detection: Welford incremental baselines per operation×asset, 3σ–7σ ladder, MIN_SAMPLES=20 | ✅ |
+| `alertmanager-notifier.ts` + `auto-remediation.ts` | SEV1–3 anomalies posted to Alertmanager v2 (annotations enriched with LLM analysis, auto-resolved after 5 min); webhook-driven remediation limited to 4 registered safe actions, gated by `AUTO_REMEDIATION_ENABLED`, with audit history endpoint | ✅ |
+| `training-store.ts` + `model-config.ts` | Good/bad rating capture with corrections, JSONL export feeding LoRA fine-tuning (r=16/α=32); runtime Ollama model switching without restart | ✅ |
+| `chaos-controller.ts` | 5 injectable failure scenarios (latency spike, error burst, slow degradation, intermittent errors, cascade); refuses to run without `CHAOS_API_KEY` | ✅ |
+| `topology-service.ts` + `ws-server.ts` | Jaeger dependency graph cached on a 5-min poll with blast-radius BFS; WebSocket fan-out of anomalies and streamed analysis chunks | ✅ |
 
-Features:
-- 5-level severity classification (SEV1-SEV5)
-- Adaptive baselines with time-of-day awareness
-- LLM-powered root cause analysis (Ollama)
-- WebSocket streaming for real-time alerts
+Features (each verifiable in the files above):
+- 5-level severity classification (SEV1-SEV5), thresholds adaptive per baseline
+- Adaptive baselines with time-of-day awareness (day-of-week × hour-of-day buckets, 168 possible per operation)
+- LLM-powered root cause analysis (Ollama), streamed over WebSocket
 - Prometheus metric correlation
+
+Known limits: `training-store.ts` persists to a local JSON file (not the database); `auto-remediation.ts` keeps its audit log in memory only; two of the four remediation actions are log-and-escalate rather than corrective. [monitor/routes.ts](../../server/monitor/routes.ts) registers 40 HTTP/WS endpoints — the Monitor Routes table below lists only the core 6.
 
 ### ✅ Structured Logging
 **Location:** [server/lib/logger.ts](../../server/lib/logger.ts)
@@ -241,6 +252,55 @@ Features:
 - Resource attributes standardized: `service.name`, `deployment.environment`, `service.version`, `service.instance.id`
 - Metrics-traces linking via exemplars; outbound DB/RabbitMQ/HTTP spans enriched with semantic attrs
 - Logging alignment: add trace/Span IDs to logs and ship via OTLP
+
+---
+
+## ZK Proof Assessment
+
+### ✅ Groth16 Proof Service
+**Location:** [server/services/zk-proof-service.ts](../../server/services/zk-proof-service.ts) (528 lines) + [server/circuits/](../../server/circuits/)
+
+| Component | What it does | Status |
+|-----------|--------------|--------|
+| `trade_integrity.circom` (63 lines) | Proves a fill executed within a stated price band (±0.5% of the Binance reference) without revealing fill price, quantity, or trader; commits `Poseidon(fillPrice, quantity, userId, timestamp, traceId)` so the OTel trace ID is cryptographically bound to the trade | ✅ |
+| `solvency.circom` (59 lines) | Proves `SUM(balances) == claimedTotal ≥ threshold` over N=8 private balances with a Poseidon reserve commitment | ✅ |
+| `zk-proof-service.ts` | Real `snarkjs.groth16.fullProve`/`verify` against compiled artifacts in `circuits/build/` (`.zkey` + verification keys present in repo); solvency proof regenerated every 60s; each proof emits OTel spans (`zk.prove` → `zk.data.fetch` → `zk.witness.generate` → `zk.proof.generate` → `zk.proof.verify`) | ✅ |
+
+Design properties verified in code:
+- Proof generation is non-blocking by contract — a failed proof never affects the trade itself
+- Server-side verification runs after every proof generation; stats endpoint reports success rate and per-circuit average proving time
+- Falls back to a logged mock mode when circuit artifacts are absent (test environments)
+
+Known limits: the trade-proof cache is an in-memory `Map` (proofs lost on restart); the solvency threshold is hard-coded to 0 (proves reserves exist, not reserves ≥ liabilities); solvency covers the top 8 USD wallets per the circuit's fixed N=8.
+
+---
+
+## MCP / AI Agent Access Assessment
+
+Two MCP servers expose the platform's telemetry to AI agents — one embedded, one standalone.
+
+### ✅ Embedded MCP Server
+**Location:** [server/mcp/index.ts](../../server/mcp/index.ts) (737 lines)
+
+| Aspect | Detail | Status |
+|--------|--------|--------|
+| Tools | 28 tools + 1 platform-overview resource: traces (5), metrics (6), logs (4), ZK proofs (4), anomalies/system health (4), Bayesian RCA (5) | ✅ |
+| Transports | stdio (default) and streamable HTTP with `/health` endpoint | ✅ |
+| Backends | Jaeger, Prometheus, Loki, the app's own monitor/ZK APIs, and the Bayesian inference service | ✅ |
+| Auth | None in HTTP mode — acceptable for local demo, not for exposure | ⚠️ |
+
+### ✅ Standalone otel-mcp-server
+**Location:** [otel-mcp-server/](../../otel-mcp-server/) (v1.2.0, separate package with its own test suite and Dockerfile)
+
+| Aspect | Detail | Status |
+|--------|--------|--------|
+| Tools | 32 tools across 7 skill plugins: traces (5), metrics (6), logs (4), Elasticsearch (5), Alertmanager (4), ZK proofs (4), system (4) | ✅ |
+| Tests | 99 passing tests across 7 test files (counted in `tests/`) | ✅ |
+| Architecture | Skill plugin registry ([src/skills.ts](../../otel-mcp-server/src/skills.ts)) — one file per backend, selectable via `--tools traces,metrics,logs` | ✅ |
+| Auth | Two layers: per-backend credentials plus client API keys (env var, mounted file, or local file); session-based streamable HTTP with per-session server instances | ✅ |
+| Self-observability | `/metrics` endpoint exports tool-call counts, backend latencies, and auth attempts | ✅ |
+
+The embedded server predates the standalone one and overlaps with it (traces/metrics/logs/ZK tools exist in both). Consolidating on the standalone package would remove ~700 lines of duplication and close the embedded server's unauthenticated-HTTP gap.
 
 ---
 
@@ -428,13 +488,13 @@ Features:
 
 ## Conclusion
 
-Krystaline has a **rock-solid backend** with exceptional observability—the core value proposition is fully realized. However, the frontend needs UI/UX polish before it can be called production-ready.
+Krystaline's backend claims are checkable against the repo: 1,100+ passing automated tests, 48 alert rules in 11 groups, a unified dashboard with 73 panels / 79 query targets, and a 22-service compose stack. However, the frontend needs UI/UX polish before it can be called production-ready.
 
 ### Strengths
-1. **Production-grade security** - Rate limiting, helmet, bcrypt, JWT
-2. **Comprehensive testing** - 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server) with isolated mocking
-3. **Best-in-class observability** - Full OTEL stack with LLM analysis
-4. **Clean architecture** - Clear separation of concerns
+1. **Layered security** - Three-tier rate limiting (300/60/15 req/min), Helmet CSP, bcrypt cost 12, JWT + hashed refresh tokens
+2. **Test coverage** - 1,100+ passing automated tests (1,088 in the main suite + 99 in otel-mcp-server) with isolated mocking
+3. **Observability with evidence** - Full OTEL stack (traces/metrics/logs), 48 alert rules / 11 groups, statistical + LLM anomaly analysis, typically 17+ spans on the full RabbitMQ trade path (observed in demo traces)
+4. **Verifiability** - Real Groth16 proofs (trade integrity + solvency) and two MCP servers (28 + 32 tools) that let any agent audit the telemetry
 5. **Real market data** - Binance WebSocket integration
 
 ### Weaknesses
@@ -443,25 +503,9 @@ Krystaline has a **rock-solid backend** with exceptional observability—the cor
 3. **Empty states** - Landing page shows zeros on fresh install
 4. **Demo flow** - Trace links not emphasized enough
 
-### Investor Demo Readiness: ⚠️ READY WITH CAVEATS
+### Investor Demo Readiness
 
-**Can demonstrate:**
-- Core user journey (register → verify → trade)
-- Real-time Binance prices
-- 17-span distributed traces in Jaeger
-- LLM-powered anomaly analysis
-- System transparency dashboard
-
-**Should avoid dwelling on:**
-- Landing page metrics (show after trades)
-- Visual inconsistencies (keep moving)
-- Empty states (pre-seed data recommended)
-
-**Recommended prep:**
-1. Run through [DEMO-WALKTHROUGH.md](../product/03_DEMO_WALKTHROUGH.md)
-2. Pre-seed demo trades
-3. Practice the Jaeger reveal moment
-4. Have fallback talking points ready
+See [docs/product/04_INVESTOR_DEMO_SCRIPT.md](../product/04_INVESTOR_DEMO_SCRIPT.md) — demo preparation and script live in the product docs.
 
 ---
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -27,6 +27,8 @@ repo; it is superseded by `docs/OBSERVABILITY_WHITEPAPER.md`.
 
 | File | Why it is archived |
 |---|---|
+| `legacy-architecture-external-services.md` | Describes the pre-rename payment-PoC/Tempo era stack; superseded by `docs/architecture/01_ARCHITECTURE.md`. |
+| `legacy-architecture-repository-summary.md` | Describes the pre-rename payment-PoC/Tempo era stack; superseded by `docs/architecture/01_ARCHITECTURE.md`. |
 | `legacy-dashboard-reliability-notes.md` | Rough notes that fed later dashboard-integrity thinking. |
 | `legacy-mcp-top-10-duplicate.md` | Duplicate of the current Top 20 MCP questions guide, including the same internal title. |
 | `legacy-mlops-for-aiops.md` | Older standalone LoRA/MLOps draft now superseded by the observability whitepaper and fine-tuning guide. |

--- a/docs/archive/legacy-architecture-external-services.md
+++ b/docs/archive/legacy-architecture-external-services.md
@@ -1,3 +1,5 @@
+> **Archived 2026-07-05:** describes the pre-rename payment-PoC era. See [../architecture/01_ARCHITECTURE.md](../architecture/01_ARCHITECTURE.md) for the current architecture.
+
 # External Services Setup for Authentic OpenTelemetry
 
 This document provides instructions for running real Kong Gateway and RabbitMQ services to generate authentic OpenTelemetry spans.

--- a/docs/archive/legacy-architecture-repository-summary.md
+++ b/docs/archive/legacy-architecture-repository-summary.md
@@ -1,3 +1,5 @@
+> **Archived 2026-07-05:** describes the pre-rename payment-PoC era. See [../architecture/01_ARCHITECTURE.md](../architecture/01_ARCHITECTURE.md) for the current architecture.
+
 # Krystaline Observability Lab Repository Summary
 
 ## Purpose


### PR DESCRIPTION
## Summary

Second PR from the documentation review (stacked on #37 — merge that first; GitHub will retarget this to `develop` automatically). This is the §2 "high-impact" tier: the two highest-traffic surfaces now lead with the project's distinctiveness, and every load-bearing claim was re-verified against code by a research pass before writing.

### README.md — front door restructure
- **"Proof, Not Promises" table above the fold**: six verified capabilities, each one click from its evidence — dual W3C context over RabbitMQ, a Groth16 proof per filled trade that commits the OTel `traceId` into the Poseidon hash, adaptive percentile-learned baselines, self-metered LLM RCA, AI agents cryptographically verifying proofs over MCP, and the measured test posture
- **"See It in Five Minutes"**: verified quickstart ending in the two wow-steps — open your own trade's 17+ span trace in Jaeger, then `GET /api/public/zk/verify/:tradeId` for a real server-side Groth16 verification
- Real trade-lifecycle mermaid (async proof branch + MCP path included), "How This Differs From Typical AIOps Demos" comparison table, three status tables consolidated into one
- **Honesty upgrades in both directions**: the RCA context builder was mislabeled `[CORE]` — it ships in full at `server/monitor/context-enricher.ts`, now `[PUBLIC]`; conversely the doc-boundary scanner is *not* actually wired to a git hook or CI, so per-commit enforcement is now listed `[BACKLOG]` instead of implied
- zk language upgraded from "concepts" to implemented reality; new benchmark numbers (proving 129–152 ms warm, verify 12–20 ms, 724-byte proofs) labeled as a dated benchmark run, with statically-verifiable wire counts / committed keys cited separately

### docs/architecture/01_ARCHITECTURE.md — rewritten from scratch
The old file described the defunct payment-PoC era (`docker-compose.external.yml`, dead file paths). The new one maps the real system in four planes — exchange flow, telemetry, analysis, proof & agent access — with file links throughout, one end-to-end mermaid, and a "Why this design" trade-offs section (dual-context RabbitMQ pattern, tail-based sampling, deterministic paging primary, local-first Ollama, anti-feedback span filter, chaos baseline freezing).

### Supporting changes
- `02_EXTERNAL_SERVICES.md` / `03_REPOSITORY_SUMMARY.md` archived (pre-rename era; zero inbound links)
- `04_TECHNICAL_ASSESSMENT.md`: unmeasurable praise → measurable statements; new zk-proof and MCP assessment sections (including an honest ⚠️ that the embedded MCP HTTP transport has no auth)
- `BRAND_POSITIONING.md`: receives the Showcase Messaging / precise-language tables moved out of README

## Process & verification
- A research pass re-verified all 18 evidence-ledger facts against code before writing; one was **refuted** (per-commit boundary enforcement) and the docs now state the truth
- Fresh zk benchmark run against the committed artifacts; wire counts re-derived from the zkey headers via snarkjs
- Adversarial review pass; both should-fix findings applied (benchmark evidence qualifier, compose-service enumeration)
- `npm run ci:check-docs` clean; link checker: every relative link/image in active docs resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)